### PR TITLE
add webhook templating

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,4 @@ linters:
   disable:
   - gochecknoglobals
   - exhaustivestruct
+  - varnamelen

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ KUBECONFIG=$(HOME)/.kube/azure-dev
 
 build:
 	git tag -d `git tag -l "helm-chart-*"`
-	goreleaser build --rm-dist --skip-validate --snapshot
+	go run github.com/goreleaser/goreleaser@latest build --rm-dist --skip-validate --snapshot
 	mv ./dist/aks-node-termination-handler_linux_amd64/aks-node-termination-handler aks-node-termination-handler
 	docker build --pull . -t paskalmaksim/aks-node-termination-handler:dev
 
@@ -26,11 +26,12 @@ run:
 	# https://t.me/joinchat/iaWV0bPT_Io5NGYy
 	go run --race ./cmd \
 	-kubeconfig=kubeconfig \
-	-node=aks-spotcpu2-24406641-vmss00000e \
+	-node=aks-spotcpu2-24406641-vmss00002v \
 	-log.level=DEBUG \
 	-log.prety \
 	-endpoint=http://localhost:28080/pkg/types/testdata/ScheduledEventsType.json \
-	-webhook.url=http://localhost:28080 \
+	-webhook.url=http://localhost:9091/metrics/job/aks-node-termination-handler \
+	-webhook.template='node_termination_event{node="{{ .Node }}"} 1' \
 	-telegram.token=1072104160:AAH2sFpHELeH5oxMmd-tsVjgTuzoYO6hSLM \
 	-telegram.chatID=-439460552
 
@@ -42,10 +43,10 @@ test:
 	go mod tidy
 	go fmt ./cmd/... ./pkg/...
 	CONFIG=testdata/config_test.yaml go test --race ./cmd/... ./pkg/...
-	golangci-lint run -v
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run -v
 
 test-release:
-	goreleaser release --snapshot --skip-publish --rm-dist
+	go run github.com/goreleaser/goreleaser@latest release --snapshot --skip-publish --rm-dist
 
 upgrade:
 	go get -v -u k8s.io/api@v0.20.9 || true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ aks-node-termination-handler/aks-node-termination-handler
 
 ## Alerting
 
-To make alerts to Telegram or Slack
+To make alerts to Telegram or Slack or Webhook
 
 ```bash
 helm upgrade aks-node-termination-handler \
@@ -34,6 +34,8 @@ aks-node-termination-handler/aks-node-termination-handler \
 --set args[0]=-webhook.url=https://hooks.slack.com/services/ID/ID/ID \
 --set args[1]=-telegram.token=<telegram token> \
 --set args[2]=-telegram.chatID=<telegram chatid> \
+--set args[3]=-webhook.url=http://prometheus-pushgateway.prometheus.svc.cluster.local:9091/metrics/job/aks-node-termination-handler \
+--set args[4]=-webhook.template='node_termination_event{node="{{ .Node }}"} 1'
 ```
 
 ## Simulate eviction

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -13,15 +13,51 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
 
 const port = ":28080"
 
+func debugHandler(w http.ResponseWriter, r *http.Request) {
+	// Create return string
+	request := []string{}
+	// Add the request string
+	url := fmt.Sprintf("%v %v %v", r.Method, r.URL, r.Proto)
+	request = append(request, url)
+	// Add the host
+	request = append(request, fmt.Sprintf("Host: %v", r.Host))
+
+	request = append(request, "--HEADERS--")
+	// Loop through headers
+	for name, headers := range r.Header {
+		name = strings.ToLower(name)
+
+		for _, h := range headers {
+			request = append(request, fmt.Sprintf("%v: %v", name, h))
+		}
+	}
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer r.Body.Close()
+
+	request = append(request, "--BODY--")
+	request = append(request, string(bodyBytes))
+
+	_, _ = w.Write([]byte(strings.Join(request, "\n")))
+}
+
 // simple server for test env.
 func main() {
+	http.HandleFunc("/debug", debugHandler)
 	http.Handle("/", http.FileServer(http.Dir(".")))
 	log.Infof("Listen %s", port)
 

--- a/pkg/alerts/templates.go
+++ b/pkg/alerts/templates.go
@@ -24,6 +24,8 @@ type TemplateMessageType struct {
 	Node     string
 	Event    types.ScheduledEventsEvent
 	Template string
+	// Used to making new line in templating results. Readonly.
+	NewLine string
 }
 
 func TemplateMessage(obj TemplateMessageType) (string, error) {
@@ -33,6 +35,8 @@ func TemplateMessage(obj TemplateMessageType) (string, error) {
 	}
 
 	var tpl bytes.Buffer
+
+	obj.NewLine = "\n"
 
 	err = tmpl.Execute(&tpl, obj)
 	if err != nil {

--- a/pkg/alerts/templates_test.go
+++ b/pkg/alerts/templates_test.go
@@ -39,3 +39,24 @@ func TestTemplateMessage(t *testing.T) {
 		t.Fatalf("want=%s,got=%s", want, tpl)
 	}
 }
+
+func TestLineBreak(t *testing.T) {
+	t.Parallel()
+
+	obj := alerts.TemplateMessageType{
+		Event: types.ScheduledEventsEvent{
+			EventId:   "someID",
+			EventType: "someType",
+		},
+		Template: `{{ .Event.EventId }}{{ .NewLine }}{{ .Event.EventType }}`,
+	}
+
+	tpl, err := alerts.TemplateMessage(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := "someID\nsomeType"; tpl != want {
+		t.Fatalf("want=%s,got=%s", want, tpl)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,34 +31,40 @@ const (
 )
 
 type Type struct {
-	ConfigFile      *string
-	LogPretty       *bool
-	LogLevel        *string
-	DevelopmentMode *bool
-	KubeConfigFile  *string
-	Endpoint        *string
-	NodeName        *string
-	Period          *time.Duration
-	TelegramToken   *string
-	TelegramChatID  *string
-	AlertMessage    *string
-	WebHookURL      *string
-	SentryDSN       *string
+	ConfigFile         *string
+	LogPretty          *bool
+	LogLevel           *string
+	DevelopmentMode    *bool
+	KubeConfigFile     *string
+	Endpoint           *string
+	NodeName           *string
+	Period             *time.Duration
+	TelegramToken      *string
+	TelegramChatID     *string
+	AlertMessage       *string
+	WebHookInsecure    *bool
+	WebHookContentType *string
+	WebHookURL         *string
+	WebHookTemplate    *string
+	SentryDSN          *string
 }
 
 var config = Type{
-	ConfigFile:     flag.String("config", os.Getenv("CONFIG"), "config file"),
-	LogLevel:       flag.String("log.level", "INFO", "log level"),
-	LogPretty:      flag.Bool("log.prety", false, "log in text"),
-	KubeConfigFile: flag.String("kubeconfig", "", "kubeconfig file"),
-	Endpoint:       flag.String("endpoint", azureEndpoint, "scheduled-events endpoint"),
-	NodeName:       flag.String("node", os.Getenv("MY_NODE_NAME"), "node to drain"),
-	Period:         flag.Duration("period", defaultPeriod, "period to scrape endpoint"),
-	TelegramToken:  flag.String("telegram.token", os.Getenv("TELEGRAM_TOKEN"), "telegram token"),
-	TelegramChatID: flag.String("telegram.chatID", os.Getenv("TELEGRAM_CHATID"), "telegram chatID"),
-	AlertMessage:   flag.String("alert.message", defaultAlertMessage, "default message"),
-	WebHookURL:     flag.String("webhook.url", os.Getenv("WEBHOOK_URL"), "send alerts to webhook"),
-	SentryDSN:      flag.String("sentry.dsn", "", "sentry DSN"),
+	ConfigFile:         flag.String("config", os.Getenv("CONFIG"), "config file"),
+	LogLevel:           flag.String("log.level", "INFO", "log level"),
+	LogPretty:          flag.Bool("log.prety", false, "log in text"),
+	KubeConfigFile:     flag.String("kubeconfig", "", "kubeconfig file"),
+	Endpoint:           flag.String("endpoint", azureEndpoint, "scheduled-events endpoint"),
+	NodeName:           flag.String("node", os.Getenv("MY_NODE_NAME"), "node to drain"),
+	Period:             flag.Duration("period", defaultPeriod, "period to scrape endpoint"),
+	TelegramToken:      flag.String("telegram.token", os.Getenv("TELEGRAM_TOKEN"), "telegram token"),
+	TelegramChatID:     flag.String("telegram.chatID", os.Getenv("TELEGRAM_CHATID"), "telegram chatID"),
+	AlertMessage:       flag.String("alert.message", defaultAlertMessage, "default message"),
+	WebHookContentType: flag.String("webhook.contentType", "application/json", "request content-type header"),
+	WebHookInsecure:    flag.Bool("webhook.insecure", false, "use insecure tls config"),
+	WebHookURL:         flag.String("webhook.url", os.Getenv("WEBHOOK_URL"), "send alerts to webhook"),
+	WebHookTemplate:    flag.String("webhook.template", "test", "request body"),
+	SentryDSN:          flag.String("sentry.dsn", "", "sentry DSN"),
 }
 
 func Check() error {

--- a/pkg/types/testdata/ScheduledEventsType.json
+++ b/pkg/types/testdata/ScheduledEventsType.json
@@ -7,7 +7,7 @@
       "ResourceType": "VirtualMachine",
       "Resources": [
         "FrontEnd_IN_0",
-        "aks-spotcpu2-24406641-vmss_14"
+        "aks-spotcpu2-24406641-vmss_103"
       ],
       "EventStatus": "Scheduled",
       "NotBefore": "Mon, 19 Sep 2016 18:29:47 GMT",


### PR DESCRIPTION
`aks-node-termination-handler` can send POST request to third party application - for example you can send to Prometheus (via Pushgate) some metrics to store eviction information.

To send eviction information to Pushgate - simply add `-webhook.url` and `-webhook.template` for example
```bash
-webhook.url=http://prometheus-pushgateway.prometheus.svc.cluster.local:9091/metrics/job/aks-node-termination-handler 
-webhook.template='node_termination_event{node="{{ .Node }}"} 1'
```
this will send to Prometheus metrics `node_termination_event{node="somenode"} 1` 

Closes: #12 

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>