### PR TITLE
Add a taint to the node before draining.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ aks-node-termination-handler/aks-node-termination-handler \
 You can test with [Simulate Eviction API](https://docs.microsoft.com/en-us/rest/api/compute/virtual-machines/simulate-eviction) and change API endpoint to correspond `virtualMachineScaleSets` that used in AKS
 
 ```bash
-POST https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmName}/virtualMachines/{vmID}/simulateEviction?api-version=2021-03-01
+POST https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/simulateEviction?api-version=2021-11-01
 ```

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -46,7 +46,7 @@ func TestDrain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := api.DrainNode(ctx, *config.Get().NodeName); err != nil {
+	if err := api.DrainNode(ctx, *config.Get().NodeName, "Preempt", "manual"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/maksim-paskal/logrus-hook-sentry v0.0.9
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.21.11
 	k8s.io/apimachinery v0.21.11
@@ -54,7 +55,6 @@ require (
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/spf13/cobra v1.1.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect

--- a/pkg/api/drain.go
+++ b/pkg/api/drain.go
@@ -16,18 +16,25 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrorrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/drain"
 )
 
 const AzureProviderID = "^azure:///subscriptions/(.+)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(.+)$" //nolint:lll
 
-var errAzureProviderIDNotValid = errors.New("azureProviderID not valid")
+var (
+	errAzureProviderIDNotValid = errors.New("azureProviderID not valid")
+	taintKeyPrefix             = "aks-node-termination-handler"
+)
 
 func GetAzureResourceName(ctx context.Context, nodeName string) (string, error) {
 	node, err := Clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
@@ -47,7 +54,7 @@ func GetAzureResourceName(ctx context.Context, nodeName string) (string, error) 
 	return result, nil
 }
 
-func DrainNode(ctx context.Context, nodeName string) error {
+func DrainNode(ctx context.Context, nodeName string, eventType string, eventID string) error {
 	log.Infof("Draining node %s", nodeName)
 
 	node, err := GetNode(ctx, nodeName)
@@ -56,9 +63,14 @@ func DrainNode(ctx context.Context, nodeName string) error {
 	}
 
 	if node.Spec.Unschedulable {
-		log.Infof("Node %s is already Unschedulable", nodeName)
+		log.Infof("Node %s is already Unschedulable", node.Name)
 
 		return nil
+	}
+
+	err = addTaint(ctx, node, getTaintKey(eventType), eventID)
+	if err != nil {
+		return errors.Wrap(err, "failed to taint node")
 	}
 
 	logger := &KubectlLogger{}
@@ -79,11 +91,60 @@ func DrainNode(ctx context.Context, nodeName string) error {
 		return errors.Wrap(err, "error in drain.RunCordonOrUncordon")
 	}
 
-	if err := drain.RunNodeDrain(helper, nodeName); err != nil {
+	if err := drain.RunNodeDrain(helper, node.Name); err != nil {
 		return errors.Wrap(err, "error in drain.RunNodeDrain")
 	}
 
 	return nil
+}
+
+func getTaintKey(eventType string) string {
+	return fmt.Sprintf("%s/%s", taintKeyPrefix, strings.ToLower(eventType))
+}
+
+func addTaint(ctx context.Context, node *corev1.Node, taintKey string, taintValue string) error {
+	freshNode := node.DeepCopy()
+
+	var err error
+
+	updateErr := wait.ExponentialBackoff(retry.DefaultBackoff, func() (bool, error) {
+		if freshNode, err = Clientset.CoreV1().Nodes().Get(ctx, freshNode.Name, metav1.GetOptions{}); err != nil {
+			nodeErr := errors.Wrap(err, fmt.Sprintf("failed to get node %s", freshNode.Name))
+			log.Error(nodeErr)
+
+			return false, nodeErr
+		}
+		err = updateNodeWith(ctx, taintKey, taintValue, err, freshNode)
+		switch {
+		case err == nil:
+			return true, nil
+		case apierrorrs.IsConflict(err):
+			return false, nil
+		case err != nil:
+			return false, errors.Wrap(err, fmt.Sprintf("failed to taint node %s with key %s", freshNode.Name, taintKey))
+		}
+
+		return false, nil
+	})
+
+	if updateErr != nil {
+		return err
+	}
+
+	log.Warnf("Successfully added taint %s on node %s", taintKey, freshNode.Name)
+
+	return nil
+}
+
+func updateNodeWith(ctx context.Context, taintKey string, taintValue string, err error, node *corev1.Node) error {
+	node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+		Key:    taintKey,
+		Value:  taintValue,
+		Effect: corev1.TaintEffectNoSchedule,
+	})
+	_, err = Clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+
+	return errors.Wrap(err, "failed to update node with taint")
 }
 
 func GetNode(ctx context.Context, nodeName string) (*corev1.Node, error) {

--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -94,7 +94,7 @@ func readEndpoint(ctx context.Context, azureResource string) error { //nolint:cy
 						log.WithError(err).Error("error in alerts.Send")
 					}
 
-					err = DrainNode(ctx, *config.Get().NodeName)
+					err = DrainNode(ctx, *config.Get().NodeName, event.EventType, event.EventId)
 					if err != nil {
 						return errors.Wrap(err, "error in DrainNode")
 					}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -67,7 +67,7 @@ func handlerHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 func handlerDrainNode(w http.ResponseWriter, r *http.Request) {
-	err := api.DrainNode(context.Background(), *config.Get().NodeName)
+	err := api.DrainNode(context.Background(), *config.Get().NodeName, "Preempt", "manual")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 


### PR DESCRIPTION
This makes it possible to detect that the pods are killed due to spot termination for example. Without tainting the node, you have no way of knowing why a job/pod was killed.

We use this information to enrich our error messages shown to the user.