### PR TITLE
print path to file that triggers node drain

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -61,7 +62,14 @@ func main() {
 	http.Handle("/", http.FileServer(http.Dir(".")))
 	log.Infof("Listen %s", port)
 
-	err := http.ListenAndServe(port, nil)
+	scheduledEventsType, err := filepath.Abs("pkg/types/testdata/ScheduledEventsType.json")
+	if err != nil {
+		log.WithError(err).Fatal()
+	}
+
+	log.Infof("edit %s file to test events", scheduledEventsType)
+
+	err = http.ListenAndServe(port, nil)
 	if err != nil {
 		log.WithError(err).Fatal()
 	}


### PR DESCRIPTION
to test `aks-node-termination-handler` localy you need run mock service that implement azure service
```bash
make run-mock
```
and start `aks-node-termination-handler` that listen to events from this mock
```bash
make run
```
than, edit `Resources` in `pkg/types/testdata/ScheduledEventsType.json` - and this will trigger node drain.

This PR will help to identify absolute path to this json file that can trigger node draining

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>