### PR TITLE
taint node with NoExecute effect after drain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ run:
 	-node=$(node) \
 	-log.level=DEBUG \
 	-log.pretty \
+	-taint.node \
+	-taint.effect=NoExecute \
 	-endpoint=http://localhost:28080/pkg/types/testdata/ScheduledEventsType.json \
 	-webhook.url=http://localhost:9091/metrics/job/aks-node-termination-handler \
 	-webhook.template='node_termination_event{node="{{ .Node }}"} 1' \


### PR DESCRIPTION
`NoExecute` taint effect do not drain node safely, this taint effect must be set after node drain

Closes: #28 

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>