### PR TITLE
add custom grace periods to drain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ deploy:
 	--set args[0]=-telegram.token=${telegramToken} \
 	--set args[1]=-telegram.chatID=${telegramChatID} \
 	--set args[2]=-taint.node \
-	--set args[3]=-taint.effect=NoExecute
+	--set args[3]=-taint.effect=NoExecute \
+	--set args[4]=-podGracePeriodSeconds=30 \
 
 clean:
 	kubectl delete ns aks-node-termination-handler
@@ -40,6 +41,7 @@ run:
 	-log.pretty \
 	-taint.node \
 	-taint.effect=NoExecute \
+	-podGracePeriodSeconds=30 \
 	-endpoint=http://localhost:28080/pkg/types/testdata/ScheduledEventsType.json \
 	-webhook.url=http://localhost:9091/metrics/job/aks-node-termination-handler \
 	-webhook.template='node_termination_event{node="{{ .Node }}"} 1' \
@@ -57,11 +59,15 @@ test:
 	go test --race -coverprofile coverage.out ./cmd/... ./pkg/...
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run -v
 
-test-e2e:
+.PHONY: e2e
+e2e:
 	go test -v -race ./e2e \
 	-kubeconfig=$(KUBECONFIG) \
 	-log.level=INFO \
 	-log.pretty \
+	-taint.node \
+	-taint.effect=NoExecute \
+	-podGracePeriodSeconds=30 \
 	-node=${node} \
 	-telegram.token=${telegramToken} \
 	-telegram.chatID=${telegramChatID}

--- a/pkg/api/drain.go
+++ b/pkg/api/drain.go
@@ -83,12 +83,12 @@ func DrainNode(ctx context.Context, nodeName string, eventType string, eventID s
 		Ctx:                 ctx,
 		Client:              Clientset,
 		Force:               true,
-		GracePeriodSeconds:  -1,
+		GracePeriodSeconds:  *config.Get().PodGracePeriodSeconds,
 		IgnoreAllDaemonSets: true,
 		Out:                 logger,
 		ErrOut:              logger,
 		DeleteEmptyDirData:  true,
-		Timeout:             time.Duration(120) * time.Second, //nolint:gomnd
+		Timeout:             time.Duration(*config.Get().NodeGracePeriodSeconds) * time.Second,
 	}
 
 	if err := drain.RunCordonOrUncordon(helper, node, true); err != nil {


### PR DESCRIPTION
add new flags `-podGracePeriodSeconds` and `-nodeGracePeriodSeconds` for grace terminations period.

Azure gives 30 seconds for spot instances to terminate pods on node before eviction. It's highly recomended to set `-podGracePeriodSeconds=30` to make force termination of pod on node. By default value `-podGracePeriodSeconds=-1` use pod's terminationGracePeriodSeconds.

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>