### PR TITLE
deprecate io/ioutil

### DIFF
--- a/pkg/alert/alert_test.go
+++ b/pkg/alert/alert_test.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -45,7 +45,7 @@ func testWebhookRequest(r *http.Request) error {
 
 	defer r.Body.Close()
 
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 
 	if bodyString := string(body); bodyString != "node_termination_event{node=\"test\"} 1\n" {
 		return fmt.Errorf("Response body [%s] is not correct", bodyString)

--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -15,7 +15,7 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -67,9 +67,9 @@ func readEndpoint(ctx context.Context, azureResource string) error { //nolint:cy
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return errors.Wrap(err, "error in ioutil.ReadAll")
+		return errors.Wrap(err, "error in io.ReadAll")
 	}
 
 	message := types.ScheduledEventsType{}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,6 @@ package config
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -119,9 +118,9 @@ func Load() error {
 		return nil
 	}
 
-	configByte, err := ioutil.ReadFile(*config.ConfigFile)
+	configByte, err := os.ReadFile(*config.ConfigFile)
 	if err != nil {
-		return errors.Wrap(err, "error in ioutil.ReadFile")
+		return errors.Wrap(err, "error in os.ReadFile")
 	}
 
 	err = yaml.Unmarshal(configByte, &config)

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -14,7 +14,7 @@ package types_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/types"
@@ -23,7 +23,7 @@ import (
 func TestScheduledEventsType(t *testing.T) {
 	t.Parallel()
 
-	messageBytes, err := ioutil.ReadFile("testdata/ScheduledEventsType.json")
+	messageBytes, err := os.ReadFile("testdata/ScheduledEventsType.json")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
"io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>