### PR TITLE
add multi arc docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+    - uses: docker/setup-qemu-action@v2
+    - uses: docker/setup-buildx-action@v2
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,14 +1,41 @@
+project_name: aks-node-termination-handler
 release:
   footer: |
     ## Docker Images
-    - `paskalmaksim/aks-node-termination-handler:latest`
-    - `paskalmaksim/aks-node-termination-handler:{{ .Tag }}`
+    - `paskalmaksim/{{.ProjectName}}:latest`
+    - `paskalmaksim/{{.ProjectName}}:{{ .Tag }}`
+docker_manifests:
+- name_template: paskalmaksim/{{.ProjectName}}:latest
+  image_templates:
+  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-amd64
+  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-arm64
+- name_template: paskalmaksim/{{.ProjectName}}:{{.Tag}}
+  image_templates:
+  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-amd64
+  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-arm64
 dockers:
-- goos: linux
+- use: buildx
+  goos: linux
   goarch: amd64
   image_templates:
-  - paskalmaksim/aks-node-termination-handler:latest
-  - paskalmaksim/aks-node-termination-handler:{{ .Tag }}
+  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-amd64
+  build_flag_templates:
+  - "--platform=linux/amd64"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.title={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+- use: buildx
+  goos: linux
+  goarch: arm64
+  image_templates:
+  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-arm64
+  build_flag_templates:
+  - "--platform=linux/arm64/v8"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.title={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
 builds:
 - dir: ./cmd/
   env:
@@ -21,6 +48,7 @@ builds:
   - linux
   goarch:
   - amd64
+  - arm64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Azure now [support](https://azure.microsoft.com/en-us/blog/azure-virtual-machines-with-ampere-altra-arm-based-processors-generally-available/) arm64 instances. Add support to build arm64 images and amd64

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>