### PR TITLE
exclude freeze events from drain node

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,7 @@ builds:
   flags:
   - -trimpath
   ldflags:
-  - -X github.com/maksim-paskal/aks-node-termination-handler/pkg/config.gitVersion={{.Version}}-{{.ShortCommit}}-{{.Timestamp}}
+  - -s -w -X github.com/maksim-paskal/aks-node-termination-handler/pkg/config.gitVersion={{.Version}}-{{.ShortCommit}}-{{.Timestamp}}
   goos:
   - linux
   goarch:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,13 +71,13 @@ func main() { //nolint:funlen
 	signalChanInterrupt := make(chan os.Signal, 1)
 	signal.Notify(signalChanInterrupt, syscall.SIGINT, syscall.SIGTERM)
 
-	go func() {
-		log.RegisterExitHandler(func() {
-			cancel()
-			// wait before shutdown
-			time.Sleep(config.Get().GracePeriod())
-		})
+	log.RegisterExitHandler(func() {
+		cancel()
+		// wait before shutdown
+		time.Sleep(config.Get().GracePeriod())
+	})
 
+	go func() {
 		select {
 		case <-signalChanInterrupt:
 			log.Error("Got interruption signal...")

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
+	github.com/google/uuid v1.3.0
 	github.com/maksim-paskal/logrus-hook-sentry v0.0.9
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
@@ -36,7 +37,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.1.2 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
-github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/pkg/api/logger.go
+++ b/pkg/api/logger.go
@@ -13,7 +13,18 @@ limitations under the License.
 package api
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrorrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 )
 
 type KubectlLogger struct{}
@@ -22,4 +33,58 @@ func (b *KubectlLogger) Write(p []byte) (int, error) {
 	log.Info(string(p))
 
 	return 0, nil
+}
+
+type eventMessage struct {
+	Type    string
+	Reason  string
+	Message string
+}
+
+func addNodeEvent(ctx context.Context, message *eventMessage) error {
+	node, err := GetNode(ctx, *config.Get().NodeName)
+	if err != nil {
+		return errors.Wrap(err, "error in GetNode")
+	}
+
+	event := corev1.Event{
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion:      "v1",
+			Kind:            "Node",
+			Name:            node.Name,
+			UID:             node.UID,
+			ResourceVersion: node.ResourceVersion,
+		},
+		Count:          1,
+		FirstTimestamp: metav1.Now(),
+		LastTimestamp:  metav1.Now(),
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s.%s", *config.Get().NodeName, uuid.New().String()),
+		},
+		Type:    message.Type,
+		Reason:  message.Reason,
+		Message: message.Message,
+		Source: corev1.EventSource{
+			Component: "aks-node-termination-handler",
+		},
+	}
+
+	err = wait.ExponentialBackoff(retry.DefaultBackoff, func() (bool, error) {
+		_, err = Clientset.CoreV1().Events("default").Create(ctx, &event, metav1.CreateOptions{})
+		switch {
+		case err == nil:
+			return true, nil
+		case apierrorrs.IsConflict(err):
+			return false, nil
+		case err != nil:
+			return false, errors.Wrap(err, "failed to create event")
+		}
+
+		return false, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to add event")
+	}
+
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -125,5 +126,27 @@ func TestConfig(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestIsExcludedEvent(t *testing.T) {
+	t.Parallel()
+
+	trueValue := true
+	falseValue := false
+
+	testConfigValid := config.Type{
+		DrainOnFreezeEvent: &falseValue,
+	}
+
+	// test DrainOnFreezeEvent logic
+	testConfigValid.DrainOnFreezeEvent = &falseValue
+	if b := testConfigValid.IsExcludedEvent(types.EventTypeFreeze); b != true {
+		t.Fatal("when DrainOnFreezeEvent is false, IsExcludedEvent must be true")
+	}
+
+	testConfigValid.DrainOnFreezeEvent = &trueValue
+	if b := testConfigValid.IsExcludedEvent(types.EventTypeFreeze); b == true {
+		t.Fatal("when DrainOnFreezeEvent is true, IsExcludedEvent must be false")
 	}
 }


### PR DESCRIPTION
add new frag `-drainOnFreezeEvent` if enabled - that will drain node on Freeze event, with this changes - all next nodes will not drain on Freeze event

also this PR logs all received scheduled events in node "events" section - you can view latest events with:
```
kubectl describe node <node>
```

Closes: #43 