### PR TITLE
add kubernetes metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ tag=dev
 image=paskalmaksim/aks-node-termination-handler:$(tag)
 telegramToken=1072104160:AAH2sFpHELeH5oxMmd-tsVjgTuzoYO6hSLM
 telegramChatID=-439460552
+node=`kubectl get no -lkubernetes.azure.com/scalesetpriority=spot | awk '{print $$1}' | tail -1` 
 
 chart-lint:
 	ct lint --all
@@ -39,7 +40,7 @@ run:
 	# https://t.me/joinchat/iaWV0bPT_Io5NGYy
 	go run --race ./cmd \
 	-kubeconfig=${KUBECONFIG} \
-	-node=`kubectl get no -lkubernetes.azure.com/scalesetpriority=spot | awk '{print $$1}' | tail -1` \
+	-node=$(node) \
 	-log.level=DEBUG \
 	-log.pretty \
 	-taint.node \

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/alert"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/api"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/client"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/template"
 )
@@ -34,7 +35,7 @@ func TestDrain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := api.Init(); err != nil {
+	if err := client.Init(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/alert"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/api"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/client"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/web"
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ func Run(ctx context.Context) error {
 		return errors.Wrap(err, "error in init alerts")
 	}
 
-	err = api.Init()
+	err = client.Init()
 	if err != nil {
 		return errors.Wrap(err, "error in init api")
 	}

--- a/pkg/api/logger.go
+++ b/pkg/api/logger.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/client"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -70,7 +71,7 @@ func addNodeEvent(ctx context.Context, message *eventMessage) error {
 	}
 
 	err = wait.ExponentialBackoff(retry.DefaultBackoff, func() (bool, error) {
-		_, err = Clientset.CoreV1().Events("default").Create(ctx, &event, metav1.CreateOptions{})
+		_, err = client.GetKubernetesClient().CoreV1().Events("default").Create(ctx, &event, metav1.CreateOptions{})
 		switch {
 		case err == nil:
 			return true, nil

--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -1,0 +1,37 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package client
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/metrics"
+)
+
+type requestResult struct {
+	Cluster string
+}
+
+func (r *requestResult) Increment(_ context.Context, code string, _ string, host string) {
+	metrics.KubernetesAPIRequest.WithLabelValues(host, code).Inc()
+}
+
+type requestLatency struct {
+	Cluster string
+}
+
+func (r *requestLatency) Observe(_ context.Context, _ string, u url.URL, latency time.Duration) {
+	metrics.KubernetesAPIRequestDuration.WithLabelValues(u.Host).Observe(latency.Seconds())
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -84,12 +84,13 @@ func (i *Instrumenter) instrumentRoundTripperEndpoint(counter *prometheus.Counte
 	}
 }
 
-var ErrorReadingEndpoint = promauto.NewCounter(
+var ErrorReadingEndpoint = promauto.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: namespace,
 		Name:      "error_reading_endpoint_total",
 		Help:      "A counter for errored reading endpoint",
 	},
+	[]string{"node", "resource"},
 )
 
 var ScheduledEventsTotal = promauto.NewCounterVec(
@@ -98,8 +99,20 @@ var ScheduledEventsTotal = promauto.NewCounterVec(
 		Name:      "scheduled_events_total",
 		Help:      "Scheduled Events from Azure",
 	},
-	[]string{"type"},
+	[]string{"node", "resource", "type"},
 )
+
+var KubernetesAPIRequest = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: namespace,
+	Name:      "apiserver_request_total",
+	Help:      "The total number of kunernetes API requests",
+}, []string{"cluster", "code"})
+
+var KubernetesAPIRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: namespace,
+	Name:      "apiserver_request_duration",
+	Help:      "The duration in seconds of kunernetes API requests",
+}, []string{"cluster"})
 
 func GetHandler() http.Handler {
 	return promhttp.Handler()

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -82,7 +82,7 @@ func handlerHealthz(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// check kubernetes API
-	if err := api.Ping(r.Context()); err != nil {
+	if _, err := api.GetNode(r.Context(), *config.Get().NodeName); err != nil {
 		log.WithError(err).Error("kubernetes API is not available")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 


### PR DESCRIPTION
add metrics for kubernetes API request, expose prometheus metrics, this metrics can help to observe kubernetes lags
```
aks_node_termination_handler_apiserver_request_duration_bucket
aks_node_termination_handler_apiserver_request_total
```

for this change, need refactor kubernetes client creation, move this funcs to `client` package

also extend metrics labels for
```
aks_node_termination_handler_error_reading_endpoint_total
aks_node_termination_handler_scheduled_events_total
```

add node and resoure labels, for better observability