### PR TITLE
listen scheduled events for all nodes in cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This tool ensures that kubernetes cluster responds appropriately to events that 
 
 Based on [Azure Scheduled Events](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events) and [Safely Drain a Node](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)
 
-## Create Azure Kubernetes Cluster with Spot Virtual Machines
-
-[Create an AKS cluster](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-cli) and at least one [Azure Spot node pool](https://learn.microsoft.com/en-us/azure/aks/spot-node-pool), [Azure Scheduled Events](https://learn.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-terminate-notification#get-terminate-notifications) will automatically enabled for all Spot Virtual Machines in Azure Kubernetes Cluster.
+## Create Azure Kubernetes Cluster
 
 <details>
   <summary>Create basic AKS cluster with Azure CLI</summary>
 
 ```bash
+# https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-cli
+
 # Azure CLI version is 2.50.0
 az --version
 
@@ -24,7 +24,7 @@ az group create \
 --name test-aks-group-eastus \
 --location eastus
 
-# Create aks cluster, with at least one system node
+# Create aks cluster, with not spot instances
 az aks create \
 --resource-group test-aks-group-eastus \
 --name MyManagedCluster \
@@ -50,9 +50,9 @@ az aks nodepool add \
 # Get config to connect to cluster
 az aks get-credentials \
 --resource-group test-aks-group-eastus \
---name MyManagedCluster \
---file=~/.kube/config
+--name MyManagedCluster
 ```
+
 </details>
 
 ## Installation

--- a/charts/aks-node-termination-handler/Chart.yaml
+++ b/charts/aks-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 icon: https://helm.sh/img/helm.svg
 name: aks-node-termination-handler
-version: 1.0.9
+version: 1.1.0
 description: Gracefully handle Azure Virtual Machines shutdown within Kubernetes
 maintainers:
 - name: maksim-paskal  # Maksim Paskal

--- a/charts/aks-node-termination-handler/values.yaml
+++ b/charts/aks-node-termination-handler/values.yaml
@@ -17,8 +17,10 @@ tolerations:
   value: "spot"
   effect: "NoSchedule"
 
-nodeSelector:
-  kubernetes.azure.com/scalesetpriority: spot
+nodeSelector: {}
+# if you want handle events only from spot instances
+# nodeSelector:
+#   kubernetes.azure.com/scalesetpriority: spot
 
 resources:
   limits:


### PR DESCRIPTION
Azure Scheduled Events send events for spot and not spot instances nodes. Historicaly this tool was used only on spot instances to gracefully terminate spot instances. This change will run pods on all nodes in cluster by default.

To run this pods only on spot instances - you need to add nodeSelector for example:
```bash
helm upgrade aks-node-termination-handler \
--install \
--namespace kube-system \
aks-node-termination-handler/aks-node-termination-handler \
--set priorityClassName=system-node-critical \
--set nodeSelector."kubernetes\.azure\.com/scalesetpriority"=spot
```