### PR TITLE
use named port

### DIFF
--- a/charts/aks-node-termination-handler/Chart.yaml
+++ b/charts/aks-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 icon: https://helm.sh/img/helm.svg
 name: aks-node-termination-handler
-version: 1.1.0
+version: 1.1.1
 description: Gracefully handle Azure Virtual Machines shutdown within Kubernetes
 maintainers:
 - name: maksim-paskal  # Maksim Paskal

--- a/charts/aks-node-termination-handler/templates/daemonset.yaml
+++ b/charts/aks-node-termination-handler/templates/daemonset.yaml
@@ -67,8 +67,12 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 17923
+            port: http
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 30
           timeoutSeconds: 5
+        ports:
+        - name: http
+          containerPort: 17923
+          protocol: TCP


### PR DESCRIPTION
Use named port instead numbers in livenessProbe also this change help users move from deprecated `targetPort` to `port` in [PodMetricsEndpoint](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#podmetricsendpoint)

Closes: #58 