### PR TITLE
Distinguish between request and drain timeouts

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -69,12 +69,12 @@ func ReadEvents(ctx context.Context, azureResource string) {
 }
 
 func readEndpoint(ctx context.Context, azureResource string) (bool, error) { //nolint:cyclop,funlen
-	ctx, cancel := context.WithTimeout(ctx, *config.Get().RequestTimeout)
+	reqCtx, cancel := context.WithTimeout(ctx, *config.Get().RequestTimeout)
 	defer cancel()
 
 	log.Debugf("read %s", *config.Get().Endpoint)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, *config.Get().Endpoint, nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, *config.Get().Endpoint, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "error in http.NewRequestWithContext")
 	}


### PR DESCRIPTION
Currently request timeout is also applied to drain node timeout. This is because request gets child ctx with timeout and the same ctx with timeout is passed to drain logic even if there is separate 120s timeout.
To fix it we have to pass main ctx to drain logic and timeouted one to request.