### PR TITLE
add windows support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,32 +6,95 @@ on:
 permissions:
   contents: write
 
+env:
+  IMAGE: paskalmaksim/aks-node-termination-handler:${{github.ref_name}}
+  IMAGE_LATEST: paskalmaksim/aks-node-termination-handler:latest
+  # IMAGE: paskalmaksim/aks-node-termination-handler:test-${{ github.run_id }}
+  # IMAGE_LATEST: paskalmaksim/aks-node-termination-handler:test-latest
+
 jobs:
-  goreleaser:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Remove Git Tags with Charts
-      run: git tag -d $(git tag -l "helm-chart-*")
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: '1.21'
-    - name: Login to Docker Hub
-      uses: docker/login-action@v1
+    - name: Remove Git Tags with Charts
+      run: git tag -d $(git tag -l "helm-chart-*")
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - run: cp Dockerfile ./dist/aks-node-termination-handler_linux_amd64_v1/Dockerfile
+    - run: cp Dockerfile ./dist/aks-node-termination-handler_linux_arm64/Dockerfile
+    - run: cp Dockerfile.windows ./dist/aks-node-termination-handler_windows_amd64_v1/Dockerfile
+    - run: tar -cvf release.tar ./dist
+    - uses: actions/upload-artifact@v4
+      with:
+        name: release
+        retention-days: 1
+        path: release.tar
+
+  publish-linux-amd64:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - uses: actions/download-artifact@v4
+    - run: tar xvf ./release/release.tar
+    - run: "docker build --pull --push --platform linux/amd64 -t ${{ env.IMAGE }}-linux-amd64 ."
+      working-directory: ./dist/aks-node-termination-handler_linux_amd64_v1
+
+  publish-linux-arm64:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - uses: docker/setup-qemu-action@v2
     - uses: docker/setup-buildx-action@v2
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+    - uses: actions/download-artifact@v4
+    - run: tar xvf ./release/release.tar
+    - run: "docker build --pull --push --platform linux/arm64 -t ${{ env.IMAGE }}-linux-arm64 ."
+      working-directory: ./dist/aks-node-termination-handler_linux_arm64
+
+  publish-windows-amd64:
+    runs-on: windows-latest
+    needs: build
+    steps:
+    - uses: docker/login-action@v3
       with:
-        distribution: goreleaser
-        version: latest
-        args: release --rm-dist
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - uses: actions/download-artifact@v4
+    - run: tar xvf ./release/release.tar
+    - run: "docker build --pull --platform windows/amd64 -t ${{ env.IMAGE }}-windows-amd64 ."
+      working-directory: ./dist/aks-node-termination-handler_windows_amd64_v1
+    - run: docker push ${{ env.IMAGE }}-windows-amd64
+
+  publish-manifest:
+    runs-on: ubuntu-latest
+    needs: [publish-linux-amd64, publish-linux-arm64, publish-windows-amd64]
+    steps:
+    - uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - run: docker manifest create ${{ env.IMAGE }} ${{ env.IMAGE }}-linux-amd64 ${{ env.IMAGE }}-linux-arm64 ${{ env.IMAGE }}-windows-amd64
+    - run: docker manifest push ${{ env.IMAGE }}
+    - run: docker manifest create ${{ env.IMAGE_LATEST }} ${{ env.IMAGE }}-linux-amd64 ${{ env.IMAGE }}-linux-arm64 ${{ env.IMAGE }}-windows-amd64
+    - run: docker manifest push ${{ env.IMAGE_LATEST }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,38 +4,6 @@ release:
     ## Docker Images
     - `paskalmaksim/{{.ProjectName}}:latest`
     - `paskalmaksim/{{.ProjectName}}:{{ .Tag }}`
-docker_manifests:
-- name_template: paskalmaksim/{{.ProjectName}}:latest
-  image_templates:
-  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-amd64
-  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-arm64
-- name_template: paskalmaksim/{{.ProjectName}}:{{.Tag}}
-  image_templates:
-  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-amd64
-  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-arm64
-dockers:
-- use: buildx
-  goos: linux
-  goarch: amd64
-  image_templates:
-  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-amd64
-  build_flag_templates:
-  - "--platform=linux/amd64"
-  - "--label=org.opencontainers.image.created={{.Date}}"
-  - "--label=org.opencontainers.image.title={{.ProjectName}}"
-  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-  - "--label=org.opencontainers.image.version={{.Version}}"
-- use: buildx
-  goos: linux
-  goarch: arm64
-  image_templates:
-  - paskalmaksim/{{.ProjectName}}:{{.Tag}}-arm64
-  build_flag_templates:
-  - "--platform=linux/arm64/v8"
-  - "--label=org.opencontainers.image.created={{.Date}}"
-  - "--label=org.opencontainers.image.title={{.ProjectName}}"
-  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-  - "--label=org.opencontainers.image.version={{.Version}}"
 builds:
 - dir: ./cmd/
   env:
@@ -46,6 +14,7 @@ builds:
   - -s -w -X github.com/maksim-paskal/aks-node-termination-handler/pkg/config.gitVersion={{.Version}}-{{.ShortCommit}}-{{.Timestamp}}
   goos:
   - linux
+  - windows
   goarch:
   - amd64
   - arm64

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+WORKDIR /app/
+
+COPY ./aks-node-termination-handler.exe /app/aks-node-termination-handler.exe
+USER ContainerUser
+
+ENTRYPOINT [ "/app/aks-node-termination-handler.exe" ]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This tool ensures that kubernetes cluster responds appropriately to events that 
 
 Based on [Azure Scheduled Events](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events) and [Safely Drain a Node](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)
 
+Support Linux (amd64, arm64) and Windows (amd64) nodes.
+
 ## Create Azure Kubernetes Cluster
 
 <details>
@@ -38,7 +40,7 @@ az aks create \
 --min-count 1 \
 --max-count 3
 
-# Create nodepool with Spot Virtual Machines and autoscaling
+# Create Linux nodepool with Spot Virtual Machines and autoscaling
 az aks nodepool add \
 --resource-group test-aks-group-eastus \
 --cluster-name MyManagedCluster \
@@ -50,6 +52,19 @@ az aks nodepool add \
 --node-vm-size Standard_DS2_v2 \
 --min-count 0 \
 --max-count 10
+
+# Create Windows nodepool with Spot Virtual Machines and autoscaling
+az aks nodepool add \
+--resource-group test-aks-group-eastus \
+--cluster-name MyManagedCluster \
+--os-type Windows \
+--priority Spot \
+--eviction-policy Delete \
+--spot-max-price -1 \
+--enable-cluster-autoscaler \
+--name spot01 \
+--min-count 1 \
+--max-count 3
 
 # Get config to connect to cluster
 az aks get-credentials \

--- a/charts/aks-node-termination-handler/Chart.yaml
+++ b/charts/aks-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 icon: https://helm.sh/img/helm.svg
 name: aks-node-termination-handler
-version: 1.1.2
+version: 1.1.3
 description: Gracefully handle Azure Virtual Machines shutdown within Kubernetes
 maintainers:
 - name: maksim-paskal  # Maksim Paskal

--- a/charts/aks-node-termination-handler/templates/daemonset.yaml
+++ b/charts/aks-node-termination-handler/templates/daemonset.yaml
@@ -50,15 +50,7 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         securityContext:
-          runAsNonRoot: true
-          runAsUser: 30523
-          runAsGroup: 30523
-          privileged: false
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
+{{ toYaml .Values.securityContext | indent 10 }}
         args:
         {{- range .Values.args }}
         - {{ . }}

--- a/charts/aks-node-termination-handler/values.yaml
+++ b/charts/aks-node-termination-handler/values.yaml
@@ -29,6 +29,17 @@ extraVolumeMounts: []
 metrics:
   addAnnotations: true
 
+securityContext:
+  runAsNonRoot: true
+  privileged: false
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  windowsOptions:
+    runAsUserName: "ContainerUser"
+
 tolerations:
 - key: "kubernetes.azure.com/scalesetpriority"
   operator: "Equal"
@@ -42,7 +53,6 @@ nodeSelector: {}
 
 resources:
   limits:
-    cpu: 20m
     memory: 100Mi
   requests:
     cpu: 20m


### PR DESCRIPTION
AKS support Linux and Windows nodepools, create CI process to build multiarch, os images:
- Linux AMD64
- Linux ARM64
- Windows AMD64

> Github Actions doesn't support runners Windows ARM64 - for now it's dificult to build docker image for Windows ARM64

Need chart update, windows pods not supporting securityContext for runAsUser and runAsGroup remove this values, add to values. Also removed `resources.limits.cpu` Windows nodes doesn't run pods with this default limit.

Closes: #67 