### PR TITLE
extend webhook data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 /aks-node-termination-handler
 simulateEviction
 coverage.out
+*.tmp

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ run:
 	-gracePeriodSeconds=0 \
 	-endpoint=http://localhost:28080/pkg/types/testdata/ScheduledEventsType.json \
 	-webhook.url=http://localhost:9091/metrics/job/aks-node-termination-handler \
-	-webhook.template='node_termination_event{node="{{ .Node }}"} 1' \
+	-webhook.template='node_termination_event{node="{{ .NodeName }}"} 1' \
 	-telegram.token=${telegramToken} \
 	-telegram.chatID=${telegramChatID} \
 	-web.address=127.0.0.1:17923

--- a/charts/aks-node-termination-handler/Chart.yaml
+++ b/charts/aks-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 icon: https://helm.sh/img/helm.svg
 name: aks-node-termination-handler
-version: 1.1.1
+version: 1.1.2
 description: Gracefully handle Azure Virtual Machines shutdown within Kubernetes
 maintainers:
 - name: maksim-paskal  # Maksim Paskal

--- a/charts/aks-node-termination-handler/templates/configmap.yaml
+++ b/charts/aks-node-termination-handler/templates/configmap.yaml
@@ -1,0 +1,8 @@
+{{ if .Values.configMap.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configMap.name }}
+data:
+{{ toYaml .Values.configMap.data | indent 2 }}
+{{ end }}

--- a/charts/aks-node-termination-handler/templates/daemonset.yaml
+++ b/charts/aks-node-termination-handler/templates/daemonset.yaml
@@ -36,6 +36,13 @@ spec:
       nodeSelector:
 {{- toYaml .Values.nodeSelector | nindent 8 }}
 {{- end }}
+      volumes:
+      - name: files
+        configMap:
+          name: {{ .Values.configMap.name }}
+      {{ if .Values.extraVolumes }}
+      {{ toYaml .Values.extraVolumes | indent 6 }}
+      {{ end }}
       containers:
       - name: aks-node-termination-handler
         resources:
@@ -76,3 +83,10 @@ spec:
         - name: http
           containerPort: 17923
           protocol: TCP
+        volumeMounts:
+        - name: files
+          mountPath: {{ .Values.configMap.mountPath }}
+          readOnly: true
+        {{ if .Values.extraVolumeMounts}}
+        {{ toYaml .Values.extraVolumeMounts | indent 8 }}
+        {{ end }}

--- a/charts/aks-node-termination-handler/values.yaml
+++ b/charts/aks-node-termination-handler/values.yaml
@@ -8,6 +8,24 @@ priorityClassName: ""
 annotations: {}
 labels: {}
 
+configMap:
+  create: true
+  name: aks-node-termination-handler-files
+  mountPath: /files
+  data: {}
+    # slack-payload.json: |
+    #   {
+    #     "channel": "#mychannel",
+    #     "username": "webhookbot",
+    #     "text": "This is message for {{ .NodeName }}, {{ .InstanceType }} from {{ .NodeRegion }}",
+    #     "icon_emoji": ":ghost:"
+    #   }
+    # prometheus-pushgateway-payload.txt: |
+    #   node_termination_event{node="{{ .NodeName }}"} 1
+
+extraVolumes: []
+extraVolumeMounts: []
+
 metrics:
   addAnnotations: true
 

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/types"
 )
 
-var ctx = context.Background()
+var ctx = context.TODO()
 
 func TestDrain(t *testing.T) {
 	t.Parallel()
@@ -46,7 +46,7 @@ func TestDrain(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := alert.SendTelegram(template.MessageType{Template: "e2e"}); err != nil {
+	if err := alert.SendTelegram(&template.MessageType{Template: "e2e"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -13,13 +13,11 @@ limitations under the License.
 package alert
 
 import (
-	"context"
 	"strconv"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/template"
-	"github.com/maksim-paskal/aks-node-termination-handler/pkg/webhook"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -56,19 +54,7 @@ func Ping() error {
 	return nil
 }
 
-func SendALL(ctx context.Context, obj template.MessageType) error {
-	if err := SendTelegram(obj); err != nil {
-		return errors.Wrap(err, "error in sending to telegram")
-	}
-
-	if err := webhook.SendWebHook(ctx, obj); err != nil {
-		return errors.Wrap(err, "error in sending to webhook")
-	}
-
-	return nil
-}
-
-func SendTelegram(obj template.MessageType) error {
+func SendTelegram(obj *template.MessageType) error {
 	if len(*config.Get().TelegramToken) == 0 {
 		return nil
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -23,7 +23,7 @@ import (
 func TestCache(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
 	go cache.SheduleCleaning(ctx)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,13 +27,13 @@ import (
 
 const (
 	azureEndpoint                 = "http://169.254.169.254/metadata/scheduledevents?api-version=2020-07-01"
-	defaultAlertMessage           = "Draining node={{ .Node }}, type={{ .Event.EventType }}"
+	defaultAlertMessage           = "Draining node={{ .NodeName }}, type={{ .Event.EventType }}"
 	defaultPeriod                 = 5 * time.Second
 	defaultPodGracePeriodSeconds  = -1
 	defaultNodeGracePeriodSeconds = 120
 	defaultGracePeriodSecond      = 10
 	defaultRequestTimeout         = 1 * time.Second
-	defaultWebHookTimeout         = 5 * time.Second
+	defaultWebHookTimeout         = 30 * time.Second
 )
 
 var (
@@ -58,6 +58,7 @@ type Type struct {
 	WebHookContentType     *string
 	WebHookURL             *string
 	WebHookTemplate        *string
+	WebHookTemplateFile    *string
 	WebHookMethod          *string
 	WebHookTimeout         *time.Duration
 	SentryDSN              *string
@@ -86,7 +87,8 @@ var config = Type{
 	WebHookContentType:     flag.String("webhook.contentType", "application/json", "request content-type header"),
 	WebHookURL:             flag.String("webhook.url", os.Getenv("WEBHOOK_URL"), "send alerts to webhook"),
 	WebHookTimeout:         flag.Duration("webhook.timeout", defaultWebHookTimeout, "request timeout"),
-	WebHookTemplate:        flag.String("webhook.template", "test", "request body"),
+	WebHookTemplate:        flag.String("webhook.template", os.Getenv("WEBHOOK_TEMPLATE"), "request body"),
+	WebHookTemplateFile:    flag.String("webhook.template-file", os.Getenv("WEBHOOK_TEMPLATE_FILE"), "path to request body template file"), //nolint:lll
 	SentryDSN:              flag.String("sentry.dsn", "", "sentry DSN"),
 	WebHTTPAddress:         flag.String("web.address", ":17923", ""),
 	TaintNode:              flag.Bool("taint.node", false, "Taint the node before cordon and draining"),

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -27,6 +27,7 @@ import (
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/template"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/types"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/utils"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/webhook"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -68,7 +69,7 @@ func ReadEvents(ctx context.Context, azureResource string) {
 	}
 }
 
-func readEndpoint(ctx context.Context, azureResource string) (bool, error) { //nolint:cyclop,funlen
+func readEndpoint(ctx context.Context, azureResource string) (bool, error) { //nolint:cyclop,funlen,gocognit
 	reqCtx, cancel := context.WithTimeout(ctx, *config.Get().RequestTimeout)
 	defer cancel()
 
@@ -131,14 +132,12 @@ func readEndpoint(ctx context.Context, azureResource string) (bool, error) { //n
 					continue
 				}
 
-				err := alert.SendALL(ctx, template.MessageType{
-					Event:    event,
-					Node:     azureResource,
-					Template: *config.Get().AlertMessage,
-				})
-				if err != nil {
-					log.WithError(err).Error("error in alerts.Send")
-				}
+				// send event in separate goroutine
+				go func() {
+					if err := sendEvent(ctx, event); err != nil {
+						log.WithError(err).Error("error in sendEvent")
+					}
+				}()
 
 				err = api.DrainNode(ctx, *config.Get().NodeName, string(event.EventType), event.EventId)
 				if err != nil {
@@ -158,4 +157,25 @@ func getsharedMetricsLabels(resourceName string) []string {
 		*config.Get().NodeName,
 		resourceName,
 	}
+}
+
+func sendEvent(ctx context.Context, event types.ScheduledEventsEvent) error {
+	message, err := template.NewMessageType(ctx, *config.Get().NodeName, event)
+	if err != nil {
+		return errors.Wrap(err, "error in template.NewMessageType")
+	}
+
+	log.Infof("Message: %+v", message)
+
+	message.Template = *config.Get().AlertMessage
+
+	if err := alert.SendTelegram(message); err != nil {
+		log.WithError(err).Error("error in alert.SendTelegram")
+	}
+
+	if err := webhook.SendWebHook(ctx, message); err != nil {
+		log.WithError(err).Error("error in webhook.SendWebHook")
+	}
+
+	return nil
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -27,7 +27,7 @@ import (
 var (
 	client = &http.Client{}
 	ts     = httptest.NewServer(metrics.GetHandler())
-	ctx    = context.Background()
+	ctx    = context.TODO()
 )
 
 func TestMetricsInc(t *testing.T) {

--- a/pkg/template/README.md
+++ b/pkg/template/README.md
@@ -1,0 +1,23 @@
+# Templating Options
+
+| Template  | Description | Example |
+| --------- | ----------- | ------- |
+| `{{ .Event.EventId }}` | Globally unique identifier for this event. | 602d9444-d2cd-49c7-8624-8643e7171297 |
+| `{{ .Event.EventType }}` | Impact this event causes. | Reboot |
+| `{{ .Event.ResourceType }}` | Type of resource this event affects. | VirtualMachine |
+| `{{ .Event.Resources }}` | List of resources this event affects. | [ FrontEnd_IN_0 ...] |
+| `{{ .Event.EventStatus }}` | Status of this event. | Scheduled |
+| `{{ .Event.NotBefore }}` | Time after which this event can start. The event is guaranteed to not start before this time. Will be blank if the event has already started | Mon, 19 Sep 2016 18:29:47 GMT |
+| `{{ .Event.Description }}` | Description of this event. | Host server is undergoing maintenance |
+| `{{ .Event.EventSource }}` | Initiator of the event. | Platform |
+| `{{ .Event.DurationInSeconds }}` | The expected duration of the interruption caused by the event. | -1 |
+| `{{ .NodeLabels }}` | Node labels | kubernetes.azure.com/agentpool:spotcpu4m16n ... |
+| `{{ .NodeName }}` | Node name | aks-spotcpu4m16n-41289323-vmss0000ny |
+| `{{ .ClusterName }}` | Node label kubernetes.azure.com/cluster | MC_EAST-US-RC-STAGE_stage-cluster_eastus |
+| `{{ .InstanceType }}` | Node label node.kubernetes.io/instance-type | Standard_D4as_v5 |
+| `{{ .NodeArch }}` | Node label kubernetes.io/arch | amd64 |
+| `{{ .NodeOS }}` | Node label kubernetes.io/os | linux |
+| `{{ .NodeRole }}` | Node label kubernetes.io/role | agent |
+| `{{ .NodeRegion }}` | Node label topology.kubernetes.io/region | eastus |
+| `{{ .NodeZone }}` | Node label topology.kubernetes.io/zone | 0 |
+| `{{ .NodePods }}` | List of pods on node | [ pod1 ...] |

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -13,6 +13,12 @@ limitations under the License.
 package template_test
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/template"
@@ -24,12 +30,13 @@ const fakeTemplate = "{{"
 func TestTemplateMessage(t *testing.T) {
 	t.Parallel()
 
-	obj := template.MessageType{
+	obj := &template.MessageType{
 		Event: types.ScheduledEventsEvent{
 			EventId:   "someID",
 			EventType: "someType",
 		},
-		Template: "test {{ .Event.EventId }} {{ .Event.EventType }}",
+		NodePods: []string{"pod1", "pod2"},
+		Template: "test {{ .Event.EventId }} {{ .Event.EventType }} {{ .NodePods}}",
 	}
 
 	tpl, err := template.Message(obj)
@@ -37,28 +44,7 @@ func TestTemplateMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want := "test someID someType"; tpl != want {
-		t.Fatalf("want=%s,got=%s", want, tpl)
-	}
-}
-
-func TestLineBreak(t *testing.T) {
-	t.Parallel()
-
-	obj := template.MessageType{
-		Event: types.ScheduledEventsEvent{
-			EventId:   "someID",
-			EventType: "someType",
-		},
-		Template: `{{ .Event.EventId }}{{ .NewLine }}{{ .Event.EventType }}`,
-	}
-
-	tpl, err := template.Message(obj)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if want := "someID\nsomeType"; tpl != want {
+	if want := "test someID someType [pod1 pod2]"; tpl != want {
 		t.Fatalf("want=%s,got=%s", want, tpl)
 	}
 }
@@ -66,7 +52,7 @@ func TestLineBreak(t *testing.T) {
 func TestFakeTemplate(t *testing.T) {
 	t.Parallel()
 
-	_, err := template.Message(template.MessageType{
+	_, err := template.Message(&template.MessageType{
 		Template: fakeTemplate,
 	})
 	if err == nil {
@@ -77,7 +63,7 @@ func TestFakeTemplate(t *testing.T) {
 func TestFakeTemplateFunc(t *testing.T) {
 	t.Parallel()
 
-	_, err := template.Message(template.MessageType{
+	_, err := template.Message(&template.MessageType{
 		Template: "{{ .DDD }}",
 	})
 	if err == nil {
@@ -85,4 +71,88 @@ func TestFakeTemplateFunc(t *testing.T) {
 	}
 
 	t.Log(err)
+}
+
+func TestTemplateMarkdown(t *testing.T) {
+	t.Parallel()
+
+	message := template.MessageType{}
+
+	messageBytes, err := os.ReadFile("testdata/message.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := json.Unmarshal(messageBytes, &message); err != nil {
+		t.Fatal(err)
+	}
+
+	printType("", message)
+
+	if err = os.WriteFile("README.md.tmp", []byte(buf.String()), 0o644); err != nil { //nolint:gosec
+		t.Fatal(err)
+	}
+}
+
+var buf strings.Builder
+
+func printType(prefix string, message interface{}) {
+	v := reflect.ValueOf(message)
+	typeOfS := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		switch typeOfS.Field(i).Name {
+		case "Template":
+		case "Event":
+			printType(typeOfS.Field(i).Name+".", v.Field(i).Interface())
+		default:
+			value := v.Field(i).Interface()
+
+			switch v.Field(i).Type().Kind() { //nolint:exhaustive
+			case reflect.Slice:
+				a := reflect.ValueOf(value).Interface().([]string) //nolint:forcetypeassert
+				if len(a) > 0 {
+					value = fmt.Sprintf("[ %s ...]", a[0])
+				}
+			case reflect.Int:
+				value = fmt.Sprintf("%d", value)
+			case reflect.Map:
+				a := reflect.ValueOf(value).Interface().(map[string]string) //nolint:forcetypeassert
+				for k, v := range a {
+					value = fmt.Sprintf("%s:%s ...", k, v)
+
+					break
+				}
+			}
+
+			buf.WriteString(fmt.Sprintf(
+				"| `{{ .%s%s }}` | %v | %v |\n",
+				prefix,
+				typeOfS.Field(i).Name,
+				typeOfS.Field(i).Tag.Get("description"),
+				value,
+			))
+		}
+	}
+}
+
+func TestNewMessageType(t *testing.T) {
+	t.Parallel()
+
+	if _, err := template.NewMessageType(context.TODO(), "!!invalid!!GetNodeLabels", types.ScheduledEventsEvent{}); err == nil { //nolint:lll
+		t.Fatal("error expected")
+	}
+
+	if _, err := template.NewMessageType(context.TODO(), "!!invalid!!GetNodePods", types.ScheduledEventsEvent{}); err == nil { //nolint:lll
+		t.Fatal("error expected")
+	}
+
+	messageType, err := template.NewMessageType(context.TODO(), "somenode", types.ScheduledEventsEvent{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if messageType.NodeName != "somenode" {
+		t.Fatal("NodePods is nil")
+	}
 }

--- a/pkg/template/testdata/message.json
+++ b/pkg/template/testdata/message.json
@@ -1,0 +1,62 @@
+{
+  "Event": {
+    "EventId": "602d9444-d2cd-49c7-8624-8643e7171297",
+    "EventType": "Reboot",
+    "ResourceType": "VirtualMachine",
+    "Resources": [
+      "FrontEnd_IN_0",
+      "aks-spotcpu2d2as-24469130-vmss_1",
+      "aks-spotcpu4m16n-41289323-vmss_862"
+    ],
+    "EventStatus": "Scheduled",
+    "NotBefore": "Mon, 19 Sep 2016 18:29:47 GMT",
+    "Description": "Host server is undergoing maintenance",
+    "EventSource": "Platform",
+    "DurationInSeconds": -1
+  },
+  "Template": "",
+  "NodeLabels": {
+    "agentpool": "spotcpu4m16n",
+    "beta.kubernetes.io/arch": "amd64",
+    "beta.kubernetes.io/instance-type": "Standard_D4as_v5",
+    "beta.kubernetes.io/os": "linux",
+    "failure-domain.beta.kubernetes.io/region": "eastus",
+    "failure-domain.beta.kubernetes.io/zone": "0",
+    "kubernetes.azure.com/agentpool": "spotcpu4m16n",
+    "kubernetes.azure.com/cluster": "MC_EAST-US-RC-STAGE_stage-cluster_eastus",
+    "kubernetes.azure.com/consolidated-additional-properties": "d9a49827-aede-11ee-832c-fe2d222ef432",
+    "kubernetes.azure.com/kubelet-identity-client-id": "6781a919-9379-417c-8aff-257ecacd1139",
+    "kubernetes.azure.com/mode": "user",
+    "kubernetes.azure.com/network-policy": "none",
+    "kubernetes.azure.com/node-image-version": "AKSUbuntu-2204gen2containerd-202312.06.0",
+    "kubernetes.azure.com/nodepool-type": "VirtualMachineScaleSets",
+    "kubernetes.azure.com/os-sku": "Ubuntu",
+    "kubernetes.azure.com/role": "agent",
+    "kubernetes.azure.com/scalesetpriority": "spot",
+    "kubernetes.azure.com/storageprofile": "managed",
+    "kubernetes.azure.com/storagetier": "Premium_LRS",
+    "kubernetes.io/arch": "amd64",
+    "kubernetes.io/hostname": "aks-spotcpu4m16n-41289323-vmss0000ny",
+    "kubernetes.io/os": "linux",
+    "kubernetes.io/role": "agent",
+    "node-role.kubernetes.io/agent": "",
+    "node.kubernetes.io/instance-type": "Standard_D4as_v5",
+    "storageprofile": "managed",
+    "storagetier": "Premium_LRS",
+    "topology.disk.csi.azure.com/zone": "",
+    "topology.kubernetes.io/region": "eastus",
+    "topology.kubernetes.io/zone": "0"
+  },
+  "NodeName": "aks-spotcpu4m16n-41289323-vmss0000ny",
+  "ClusterName": "MC_EAST-US-RC-STAGE_stage-cluster_eastus",
+  "InstanceType": "Standard_D4as_v5",
+  "NodeArch": "amd64",
+  "NodeOS": "linux",
+  "NodeRole": "agent",
+  "NodeRegion": "eastus",
+  "NodeZone": "0",
+  "NodePods": [
+    "pod1",
+    "pod2"
+  ]
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -32,15 +32,15 @@ const (
 
 // https://docs.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events
 type ScheduledEventsEvent struct {
-	EventId           string //nolint:golint,revive,stylecheck
-	EventType         ScheduledEventsEventType
-	ResourceType      string
-	Resources         []string
-	EventStatus       string
-	NotBefore         string // Mon, 19 Sep 2016 18:29:47 GMT
-	Description       string
-	EventSource       string
-	DurationInSeconds int
+	EventId           string                   `description:"Globally unique identifier for this event."` //nolint:golint,revive,stylecheck,lll
+	EventType         ScheduledEventsEventType `description:"Impact this event causes."`
+	ResourceType      string                   `description:"Type of resource this event affects."`
+	Resources         []string                 `description:"List of resources this event affects."`
+	EventStatus       string                   `description:"Status of this event."`
+	NotBefore         string                   `description:"Time after which this event can start. The event is guaranteed to not start before this time. Will be blank if the event has already started"` //nolint:lll
+	Description       string                   `description:"Description of this event."`
+	EventSource       string                   `description:"Initiator of the event."`
+	DurationInSeconds int                      `description:"The expected duration of the interruption caused by the event."` //nolint:lll
 }
 
 // api-version=2020-07-01.

--- a/pkg/webhook/testdata/WebhookTemplateFile.txt
+++ b/pkg/webhook/testdata/WebhookTemplateFile.txt
@@ -1,0 +1,1 @@
+node_termination_event{node="{{ .NodeName }}"} 1


### PR DESCRIPTION
Extend templating instruments for webhook usage:
- Extend templates variables. Read more in README
- Update README with information how to setup Slack
- Raise default webhook timeout to 30s
- Load payload from file (ConfigMap)

_BREAKDOWN CHANGES_
- removed template `{{ .Node }}`, now you must use `{{ .NodeName }}`
- removed template `{{ .NewLine }}`, if you need new line symbol - load your template from file


Closes: #66 