### PR TITLE
Handle empty event response

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -93,6 +93,11 @@ func readEndpoint(ctx context.Context, azureResource string) (bool, error) { //n
 		return false, errors.Wrap(err, "error in io.ReadAll")
 	}
 
+	if len(body) == 0 {
+		log.Info("Scheduled events response is empty")
+		return false, nil
+	}
+
 	message := types.ScheduledEventsType{}
 
 	err = json.Unmarshal(body, &message)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -95,7 +95,8 @@ func readEndpoint(ctx context.Context, azureResource string) (bool, error) { //n
 	}
 
 	if len(body) == 0 {
-		log.Info("Events response is empty")
+		log.Warn("Events response is empty")
+
 		return false, nil
 	}
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -95,7 +95,7 @@ func readEndpoint(ctx context.Context, azureResource string) (bool, error) { //n
 	}
 
 	if len(body) == 0 {
-		log.Info("Scheduled events response is empty")
+		log.Info("Events response is empty")
 		return false, nil
 	}
 


### PR DESCRIPTION
Currently when there are no events scheduled for a node, the endpoint 
`curl -H Metadata:true http://169.254.169.254/metadata/scheduledevents?api-version=2020-07-01` 
- either returns a valid object with empty events array as shown in Scenario-1 
- or returns empty response as shown in Scenario-2

**Scenario-1** 
<img width="775" alt="Screenshot 2024-01-12 at 5 04 12 PM" src="https://github.com/maksim-paskal/aks-node-termination-handler/assets/135721969/cd9295f3-3491-47cc-8273-e59a1c882423">

**Scenarioa-2**
<img width="1006" alt="Screenshot 2024-01-12 at 4 45 52 PM" src="https://github.com/maksim-paskal/aks-node-termination-handler/assets/135721969/85451869-7533-4a54-8b86-2d3722595858">

In our Azure nodes, the termination handler has been exclusively logging `json unmarshal errors` as the node's scheduled events response is empty.

``` json
{
  "error": "error in json.Unmarshal: unexpected end of JSON input",
  "level": "error",
  "msg": "",
  "time": "2024-01-30T15:27:06Z"
}
```

Receiving empty response from the scheduled events endpoint is a _valid_ scenario, we should not treat this as an error. In this PR we are logging the required message at info level and returns no error if the response body is empty.