### PR TITLE
Windows 2019 support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
       with:
         distribution: goreleaser
         version: latest
+        # args: build --clean --skip=validate --snapshot
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +75,9 @@ jobs:
 
   publish-windows-amd64:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        windows-version: [ 'ltsc2019', 'ltsc2022' ]
     needs: build
     steps:
     - uses: docker/login-action@v3
@@ -82,9 +86,9 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
     - uses: actions/download-artifact@v4
     - run: tar xvf ./release/release.tar
-    - run: "docker build --pull --platform windows/amd64 -t ${{ env.IMAGE }}-windows-amd64 ."
+    - run: "docker build --build-arg WINDOWS_VERSION=${{ matrix.windows-version }} --pull --platform windows/amd64 -t ${{ env.IMAGE }}-windows-${{ matrix.windows-version }}-amd64 ."
       working-directory: ./dist/aks-node-termination-handler_windows_amd64_v1
-    - run: docker push ${{ env.IMAGE }}-windows-amd64
+    - run: docker push ${{ env.IMAGE }}-windows-${{ matrix.windows-version }}-amd64
 
   publish-manifest:
     runs-on: ubuntu-latest
@@ -94,7 +98,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - run: docker manifest create ${{ env.IMAGE }} ${{ env.IMAGE }}-linux-amd64 ${{ env.IMAGE }}-linux-arm64 ${{ env.IMAGE }}-windows-amd64
+    - run: docker manifest create ${{ env.IMAGE }} ${{ env.IMAGE }}-linux-amd64 ${{ env.IMAGE }}-linux-arm64 ${{ env.IMAGE }}-windows-ltsc2022-amd64
     - run: docker manifest push ${{ env.IMAGE }}
-    - run: docker manifest create ${{ env.IMAGE_LATEST }} ${{ env.IMAGE }}-linux-amd64 ${{ env.IMAGE }}-linux-arm64 ${{ env.IMAGE }}-windows-amd64
+    - run: docker manifest create ${{ env.IMAGE_LATEST }} ${{ env.IMAGE }}-linux-amd64 ${{ env.IMAGE }}-linux-arm64 ${{ env.IMAGE }}-windows-ltsc2022-amd64
     - run: docker manifest push ${{ env.IMAGE_LATEST }}
+    - run: docker manifest create ${{ env.IMAGE_LATEST }}-ltsc2019 ${{ env.IMAGE }}-linux-amd64 ${{ env.IMAGE }}-linux-arm64 ${{ env.IMAGE }}-windows-ltsc2019-amd64
+    - run: docker manifest push ${{ env.IMAGE_LATEST }}-ltsc2019

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+ARG WINDOWS_VERSION=ltsc2022
+
+FROM mcr.microsoft.com/windows/nanoserver:$WINDOWS_VERSION
 
 WORKDIR /app/
 

--- a/charts/aks-node-termination-handler/Chart.yaml
+++ b/charts/aks-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 icon: https://helm.sh/img/helm.svg
 name: aks-node-termination-handler
-version: 1.1.3
+version: 1.1.4
 description: Gracefully handle Azure Virtual Machines shutdown within Kubernetes
 maintainers:
 - name: maksim-paskal  # Maksim Paskal

--- a/charts/aks-node-termination-handler/templates/configmap.yaml
+++ b/charts/aks-node-termination-handler/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.configMap.name }}
+  name: {{ tpl .Values.configMap.name . }}
 data:
 {{ toYaml .Values.configMap.data | indent 2 }}
 {{ end }}

--- a/charts/aks-node-termination-handler/templates/daemonset.yaml
+++ b/charts/aks-node-termination-handler/templates/daemonset.yaml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: aks-node-termination-handler
+  name: {{ .Release.Name }}
   labels:
-    app: aks-node-termination-handler
+    app: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: aks-node-termination-handler
+      app: {{ .Release.Name }}
   template:
     metadata:
       annotations:
@@ -19,12 +19,12 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
 {{ end }}
       labels:
-        app: aks-node-termination-handler
+        app: {{ .Release.Name }}
 {{ if .Values.labels }}
 {{ toYaml .Values.labels | indent 8 }}
 {{ end }}
     spec:
-      serviceAccount: aks-node-termination-handler
+      serviceAccount: {{ .Release.Name }}
       {{ if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{ end }}
@@ -36,10 +36,14 @@ spec:
       nodeSelector:
 {{- toYaml .Values.nodeSelector | nindent 8 }}
 {{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{- toYaml .Values.affinity | nindent 8 }}
+{{- end }}
       volumes:
       - name: files
         configMap:
-          name: {{ .Values.configMap.name }}
+          name: {{ tpl .Values.configMap.name . }}
       {{ if .Values.extraVolumes }}
       {{ toYaml .Values.extraVolumes | indent 6 }}
       {{ end }}

--- a/charts/aks-node-termination-handler/templates/rbac.yaml
+++ b/charts/aks-node-termination-handler/templates/rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: aks-node-termination-handler
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aks-node-termination-handler
+  name: {{ .Release.Name }}
 rules:
 - apiGroups:
   - ""
@@ -53,12 +53,12 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aks-node-termination-handler
+  name: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: aks-node-termination-handler
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: aks-node-termination-handler
+  name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/aks-node-termination-handler/values.yaml
+++ b/charts/aks-node-termination-handler/values.yaml
@@ -10,7 +10,7 @@ labels: {}
 
 configMap:
   create: true
-  name: aks-node-termination-handler-files
+  name: "{{ .Release.Name }}-files"
   mountPath: /files
   data: {}
     # slack-payload.json: |
@@ -39,6 +39,8 @@ securityContext:
     - ALL
   windowsOptions:
     runAsUserName: "ContainerUser"
+
+affinity: {}
 
 tolerations:
 - key: "kubernetes.azure.com/scalesetpriority"


### PR DESCRIPTION
AKS offered Windows 2019 for early version of cluster. Add support for this version.

> Windows Server 2022 is the default operating system for Kubernetes versions 1.25.0 and higher. Windows Server 2019 is the default OS for earlier versions.

Issues: #67