### PR TITLE
Increase timeouts for requests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ const (
 	defaultPodGracePeriodSeconds  = -1
 	defaultNodeGracePeriodSeconds = 120
 	defaultGracePeriodSecond      = 10
-	defaultRequestTimeout         = 1 * time.Second
+	defaultRequestTimeout         = 5 * time.Second
 	defaultWebHookTimeout         = 30 * time.Second
 )
 


### PR DESCRIPTION
Sometimes requests to [Azure Scheduled Events](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events) is interrupted by timeout `1s` - raise this timeout to `5s`