### PR TITLE
add OpenShift support

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,3 +265,18 @@ helm upgrade aks-node-termination-handler-windows-2019 \
 aks-node-termination-handler/aks-node-termination-handler \
 --values=linux-windows2019.values.yaml
 ```
+
+## Red Hat OpenShift support
+
+For OpenShift clusters that use Azure computes for their nodes, you must enable pod hostNetwork support because OpenShift networking has a [restriction](https://docs.openshift.com/container-platform/4.15/networking/understanding-networking.html) for using Azure Metadata Service.
+
+This support can be enabled with `--set hostNetwork=true`
+
+```bash
+helm upgrade aks-node-termination-handler \
+--install \
+--namespace kube-system \
+aks-node-termination-handler/aks-node-termination-handler \
+--set priorityClassName=system-node-critical \
+--set hostNetwork=true
+```

--- a/charts/aks-node-termination-handler/Chart.yaml
+++ b/charts/aks-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 icon: https://helm.sh/img/helm.svg
 name: aks-node-termination-handler
-version: 1.1.4
+version: 1.1.5
 description: Gracefully handle Azure Virtual Machines shutdown within Kubernetes
 maintainers:
 - name: maksim-paskal  # Maksim Paskal

--- a/charts/aks-node-termination-handler/templates/daemonset.yaml
+++ b/charts/aks-node-termination-handler/templates/daemonset.yaml
@@ -24,6 +24,7 @@ spec:
 {{ toYaml .Values.labels | indent 8 }}
 {{ end }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork }}
       serviceAccount: {{ .Release.Name }}
       {{ if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/charts/aks-node-termination-handler/values.yaml
+++ b/charts/aks-node-termination-handler/values.yaml
@@ -29,6 +29,8 @@ extraVolumeMounts: []
 metrics:
   addAnnotations: true
 
+hostNetwork: false
+
 securityContext:
   runAsNonRoot: true
   privileged: false
@@ -39,6 +41,8 @@ securityContext:
     - ALL
   windowsOptions:
     runAsUserName: "ContainerUser"
+  seccompProfile:
+    type: RuntimeDefault
 
 affinity: {}
 


### PR DESCRIPTION
Azure offers [Red Hat OpenShift](https://azure.microsoft.com/en-us/products/openshift/), and clients can also deploy a self-managed cluster. The nodes of this cluster can handle the [Azure Metadata Service](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events) in the same way as [AKS](https://azure.microsoft.com/en-us/products/kubernetes-service) managed nodes.

The difference is that AKS uses `virtualMachineScaleSets`, while OpenShift and self-managed cluster uses `virtualMachines` for their nodes.

This change can help Azure customers that use OpenShift or self-managed kubernetes clusters for their infrastucture.

Closes: #75