### PR TITLE
support kubernetes 1.29

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k3s_version: ["v1.26.11+k3s2","v1.27.8+k3s2","v1.28.4+k3s2"]
+        k3s_version: ["v1.26.11+k3s2","v1.27.8+k3s2","v1.28.4+k3s2","v1.29.2+k3s1"]
     steps:
     - name: Setup Kubernetes
       run: curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ matrix.k3s_version }}" K3S_KUBECONFIG_MODE=777 sh -


### PR DESCRIPTION
AKS now support kubernetes 1.29 preview, add e2e test to make test in this kubernetes version