### PR TITLE
refactor e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,6 @@ test:
 e2e:
 	go test -v -race ./e2e \
 	-kubeconfig=$(KUBECONFIG) \
-	-log.level=INFO \
-	-log.pretty \
-	-taint.node \
-	-taint.effect=NoExecute \
-	-podGracePeriodSeconds=30 \
 	-node=${node} \
 	-telegram.token=${telegramToken} \
 	-telegram.chatID=${telegramChatID}

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,4 @@ ignore:
 # ignore because to test need active connection to the kubernetes cluster
 - "pkg/web/web.go"
 - "pkg/api/api.go"
-- "pkg/events/events.go"
 - "pkg/client/client.go"

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -14,51 +14,135 @@ package main_test
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/maksim-paskal/aks-node-termination-handler/pkg/alert"
-	"github.com/maksim-paskal/aks-node-termination-handler/pkg/api"
+	"github.com/maksim-paskal/aks-node-termination-handler/internal"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/client"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
-	"github.com/maksim-paskal/aks-node-termination-handler/pkg/template"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/types"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var ctx = context.TODO()
+const (
+	azureResourceName = "test-e2e-resource"
+	eventID           = "test-event-id"
+	eventType         = types.EventTypePreempt
+	taintKey          = "aks-node-termination-handler/preempt"
+	taintEffect       = corev1.TaintEffectNoSchedule
+)
 
-func TestDrain(t *testing.T) {
+func TestDrain(t *testing.T) { //nolint:funlen,cyclop
 	t.Parallel()
 
+	log.SetLevel(log.DebugLevel)
+	log.SetReportCaller(true)
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/document", func(w http.ResponseWriter, _ *http.Request) {
+		message, _ := json.Marshal(types.ScheduledEventsType{
+			DocumentIncarnation: 1,
+			Events: []types.ScheduledEventsEvent{
+				{
+					EventId:      eventID,
+					EventType:    eventType,
+					ResourceType: "resourceType",
+					Resources:    []string{azureResourceName},
+				},
+			},
+		})
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(message)
+	})
+
+	testServer := httptest.NewServer(handler)
+
 	_ = flag.Set("config", "./testdata/config_test.yaml")
+	_ = flag.Set("endpoint", testServer.URL+"/document")
+	_ = flag.Set("resource.name", azureResourceName)
 
 	flag.Parse()
 
-	if err := config.Load(); err != nil {
+	ctx := context.TODO()
+
+	if err := internal.Run(ctx); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := client.Init(); err != nil {
+	node, err := client.GetKubernetesClient().CoreV1().Nodes().Get(ctx, *config.Get().NodeName, metav1.GetOptions{})
+	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := alert.Init(); err != nil {
-		t.Fatal(err)
+	if !node.Spec.Unschedulable {
+		t.Fatal("node must be unschedulable")
 	}
 
-	if err := alert.SendTelegram(&template.MessageType{Template: "e2e"}); err != nil {
-		t.Fatal(err)
+	if len(node.Spec.Taints) == 0 {
+		t.Fatal("node must have taints")
 	}
 
-	if err := api.DrainNode(ctx, *config.Get().NodeName, "Preempt", "manual"); err != nil {
-		t.Fatal(err)
+	taintFound := false
+
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == taintKey && taint.Value == eventID && taint.Effect == taintEffect {
+			taintFound = true
+
+			break
+		}
 	}
 
-	if err := api.AddNodeEvent(ctx, &types.EventMessage{
-		Type:    "Info",
-		Reason:  "TestDrain",
-		Message: "TestDrain",
-	}); err != nil {
+	if !taintFound {
+		t.Fatal("taint not found")
+	}
+
+	if err := checkNodeEvent(ctx); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func checkNodeEvent(ctx context.Context) error { //nolint:cyclop
+	events, err := client.GetKubernetesClient().CoreV1().Events("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "error in list events")
+	}
+
+	nodeName := *config.Get().NodeName
+	eventMessageReceived := 0
+	eventMessageBeforeListen := 0
+
+	for _, event := range events.Items {
+		if event.Source.Component != "aks-node-termination-handler" {
+			continue
+		}
+
+		if event.InvolvedObject.Name != nodeName {
+			continue
+		}
+
+		if event.Reason == eventType && event.Message == config.EventMessageReceived {
+			eventMessageReceived++
+		}
+
+		if event.Reason == "ReadEvents" && event.Message == config.EventMessageBeforeListen {
+			eventMessageBeforeListen++
+		}
+	}
+
+	if eventMessageReceived == 0 {
+		return errors.New("eventMessageReceived not found in events")
+	}
+
+	if eventMessageBeforeListen == 0 {
+		return errors.New("eventMessageBeforeListen not found in events")
+	}
+
+	return nil
 }

--- a/e2e/testdata/config_test.yaml
+++ b/e2e/testdata/config_test.yaml
@@ -1,2 +1,4 @@
-taintNode: true
-taintEffect: NoSchedule
+taintnode: true
+tainteffect: NoSchedule
+podgraceperiodseconds: 30
+exitafternodedrain: true

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -21,20 +21,23 @@ import (
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/client"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/events"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/template"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/types"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/web"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/webhook"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 func Run(ctx context.Context) error {
-	err := config.Check()
-	if err != nil {
-		return errors.Wrap(err, "error in config check")
-	}
-
-	err = config.Load()
+	err := config.Load()
 	if err != nil {
 		return errors.Wrap(err, "error in config load")
+	}
+
+	err = config.Check()
+	if err != nil {
+		return errors.Wrap(err, "error in config check")
 	}
 
 	log.Debugf("using config: %s", config.Get().String())
@@ -49,14 +52,93 @@ func Run(ctx context.Context) error {
 		return errors.Wrap(err, "error in init api")
 	}
 
+	go cache.SheduleCleaning(ctx)
+	go web.Start(ctx)
+
+	if err := startReadingEvents(ctx); err != nil {
+		return errors.Wrap(err, "error in startReadingEvents")
+	}
+
+	return nil
+}
+
+func startReadingEvents(ctx context.Context) error {
 	azureResource, err := api.GetAzureResourceName(ctx, *config.Get().NodeName)
 	if err != nil {
 		return errors.Wrap(err, "error in getting azure resource name")
 	}
 
-	go cache.SheduleCleaning(ctx)
-	go events.ReadEvents(ctx, azureResource)
-	go web.Start(ctx)
+	eventReader := events.NewReader()
+	eventReader.AzureResource = azureResource
+	eventReader.Period = *config.Get().Period
+	eventReader.Endpoint = *config.Get().Endpoint
+	eventReader.RequestTimeout = *config.Get().RequestTimeout
+	eventReader.NodeName = *config.Get().NodeName
+	eventReader.BeforeReading = func(ctx context.Context) error {
+		// add event to node
+		if err := api.AddNodeEvent(ctx, "Info", "ReadEvents", config.EventMessageBeforeListen); err != nil {
+			return errors.Wrap(err, "error in add node event")
+		}
+
+		return nil
+	}
+
+	eventReader.EventReceived = func(ctx context.Context, event types.ScheduledEventsEvent) (bool, error) {
+		// add event to node
+		if err := api.AddNodeEvent(ctx, "Warning", string(event.EventType), config.EventMessageReceived); err != nil {
+			return false, errors.Wrap(err, "error in add node event")
+		}
+
+		// check if event is excludedm by default Freeze event is excluded
+		if config.Get().IsExcludedEvent(event.EventType) {
+			log.Infof("Excluded event %s by user config", event.EventType)
+
+			return false, nil
+		}
+
+		// send event in separate goroutine
+		go func() {
+			if err := sendEvent(ctx, event); err != nil {
+				log.WithError(err).Error("error in sendEvent")
+			}
+		}()
+
+		// drain node
+		if err := api.DrainNode(ctx, *config.Get().NodeName, string(event.EventType), event.EventId); err != nil {
+			return false, errors.Wrap(err, "error in DrainNode")
+		}
+
+		return true, nil
+	}
+
+	// check for run in synchronous mode or not
+	// synchronous mode is used for e2e tests
+	if *config.Get().ExitAfterNodeDrain {
+		eventReader.ReadEvents(ctx)
+	} else {
+		go eventReader.ReadEvents(ctx)
+	}
+
+	return nil
+}
+
+func sendEvent(ctx context.Context, event types.ScheduledEventsEvent) error {
+	message, err := template.NewMessageType(ctx, *config.Get().NodeName, event)
+	if err != nil {
+		return errors.Wrap(err, "error in template.NewMessageType")
+	}
+
+	log.Infof("Message: %+v", message)
+
+	message.Template = *config.Get().AlertMessage
+
+	if err := alert.SendTelegram(message); err != nil {
+		log.WithError(err).Error("error in alert.SendTelegram")
+	}
+
+	if err := webhook.SendWebHook(ctx, message); err != nil {
+		log.WithError(err).Error("error in webhook.SendWebHook")
+	}
 
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,11 @@ const (
 	defaultWebHookTimeout         = 30 * time.Second
 )
 
+const (
+	EventMessageReceived     = "Azure API sended schedule event for this node"
+	EventMessageBeforeListen = "Start to listen events from Azure API"
+)
+
 var (
 	errNoNode             = errors.New("no node name is defined, run with -node=test")
 	errChatIDMustBeInt    = errors.New("TelegramChatID must be integer")
@@ -69,6 +74,8 @@ type Type struct {
 	NodeGracePeriodSeconds *int
 	GracePeriodSeconds     *int
 	DrainOnFreezeEvent     *bool
+	ResourceName           *string
+	ExitAfterNodeDrain     *bool
 }
 
 var config = Type{
@@ -97,6 +104,8 @@ var config = Type{
 	NodeGracePeriodSeconds: flag.Int("nodeGracePeriodSeconds", defaultNodeGracePeriodSeconds, "maximum time in seconds to drain the node"),  //nolint:lll
 	GracePeriodSeconds:     flag.Int("gracePeriodSeconds", defaultGracePeriodSecond, "grace period is seconds for application termination"), //nolint:lll
 	DrainOnFreezeEvent:     flag.Bool("drainOnFreezeEvent", false, "drain node on freeze event"),
+	ResourceName:           flag.String("resource.name", "", "Azure resource name to drain"),
+	ExitAfterNodeDrain:     flag.Bool("exitAfterNodeDrain", false, "process will exit after node drain"),
 }
 
 func (t *Type) GracePeriod() time.Duration {

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package events_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/events"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/types"
+	"github.com/maksim-paskal/aks-node-termination-handler/pkg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+func TestReadingEvents(t *testing.T) { //nolint:funlen
+	t.Parallel()
+
+	log.SetLevel(log.DebugLevel)
+
+	ctx := context.TODO()
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/badjson", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`!!!{"DocumentIncarnation":1,"Events":[]}`))
+	})
+	handler.HandleFunc("/emptyjson", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(``))
+	})
+	handler.HandleFunc("/incorrectcontentlen", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("Content-Length", "50")
+
+		_, _ = w.Write([]byte("a"))
+	})
+	handler.HandleFunc("/timeout", func(w http.ResponseWriter, r *http.Request) {
+		utils.SleepWithContext(r.Context(), 5*time.Second)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(``))
+	})
+	handler.HandleFunc("/document", func(w http.ResponseWriter, _ *http.Request) {
+		message, _ := json.Marshal(types.ScheduledEventsType{
+			DocumentIncarnation: 1,
+			Events: []types.ScheduledEventsEvent{
+				{
+					EventId:      time.Now().String(),
+					EventType:    types.EventTypeFreeze,
+					ResourceType: "resourceType",
+					Resources:    []string{"resource1", "resource2"},
+				},
+			},
+		})
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(message)
+	})
+
+	testServer := httptest.NewServer(handler)
+
+	t.Run("badjson", func(t *testing.T) {
+		t.Parallel()
+
+		eventReader := events.NewReader()
+		eventReader.Endpoint = testServer.URL + "/badjson"
+
+		if _, err := eventReader.ReadEndpoint(ctx); err == nil {
+			t.Error("expected error")
+		}
+	})
+
+	t.Run("badhttp", func(t *testing.T) {
+		t.Parallel()
+
+		eventReader := events.NewReader()
+		eventReader.Method = "bad method"
+		eventReader.Endpoint = "fake://fake"
+
+		if _, err := eventReader.ReadEndpoint(ctx); err == nil {
+			t.Error("expected error")
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+
+		eventReader.ReadEvents(ctx)
+	})
+
+	t.Run("badhttpcontent", func(t *testing.T) {
+		t.Parallel()
+
+		eventReader := events.NewReader()
+		eventReader.Endpoint = testServer.URL + "/incorrectcontentlen"
+
+		if _, err := eventReader.ReadEndpoint(ctx); err == nil {
+			t.Error("expected error")
+		}
+	})
+
+	t.Run("emptyjson", func(t *testing.T) {
+		t.Parallel()
+
+		eventReader := events.NewReader()
+		eventReader.Endpoint = testServer.URL + "/emptyjson"
+
+		if _, err := eventReader.ReadEndpoint(ctx); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		t.Parallel()
+
+		eventReader := events.NewReader()
+		eventReader.Endpoint = testServer.URL + "/timeout"
+		eventReader.RequestTimeout = 1 * time.Second
+
+		if _, err := eventReader.ReadEndpoint(ctx); !errors.Is(err, context.DeadlineExceeded) {
+			t.Error(err)
+		}
+	})
+
+	t.Run("document", func(t *testing.T) {
+		t.Parallel()
+
+		receivedDocument := types.ScheduledEventsEvent{}
+
+		eventReader := events.NewReader()
+		eventReader.Endpoint = testServer.URL + "/document"
+		eventReader.AzureResource = "resource1"
+		eventReader.BeforeReading = func(_ context.Context) error {
+			return errors.New("error in BeforeReading") //nolint:goerr113
+		}
+		eventReader.EventReceived = func(_ context.Context, event types.ScheduledEventsEvent) (bool, error) {
+			receivedDocument = event
+
+			return true, nil
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		eventReader.ReadEvents(ctx)
+
+		t.Logf("%+v", receivedDocument)
+
+		if receivedDocument.EventId == "" {
+			t.Error("unexpected event id")
+		}
+	})
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,9 +15,13 @@ package utils
 import (
 	"context"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func SleepWithContext(ctx context.Context, d time.Duration) {
+	log.Debugf("Sleep %s", d)
+
 	select {
 	case <-ctx.Done():
 		return


### PR DESCRIPTION
Make more reliable e2e test, use same execution logic, as main process. Separate event receiver from main logic, make unit test for event package.

Add new flags:
- `-resource.name` this flag will ignore Azure resourcename from node, will wait events from this resource 
- `-exitAfterNodeDrain` this flag is needed by e2e tests, this flag wil exits  after drain, default false

