### PR TITLE
Using HTTP Proxy for Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,37 @@ aks-node-termination-handler/aks-node-termination-handler \
 ```
 </details>
 
+<details>
+  <summary>Use an HTTP proxy for making webhook requests</summary>
+
+Use the flag `-webhook.http-proxy=http://someproxy:3128` for making requests with a proxy. This flag can use HTTP or HTTPS addresses. You can also use basic auth.
+
+```bash
+cat <<EOF | tee values.yaml
+priorityClassName: system-node-critical
+
+args:
+- -webhook.url=https://someserver/somepath
+- -webhook.template-file=/files/payload.json
+- -webhook.contentType=text/plain
+- -webhook.method=POST
+- -webhook.timeout=30s
+- -webhook.http-proxy=https://someproxy:3128
+
+configMap:
+  data:
+    payload.json: "This is message for {{ .NodeName }}, {{ .InstanceType }} from {{ .NodeRegion }}"
+EOF
+
+# install/upgrade helm chart
+helm upgrade aks-node-termination-handler \
+--install \
+--namespace kube-system \
+aks-node-termination-handler/aks-node-termination-handler \
+--values values.yaml
+```
+</details>
+
 ## Simulate eviction
 
 ### Using Azure CLI

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,8 @@ type Type struct {
 	WebHookTemplateFile    *string
 	WebHookMethod          *string
 	WebHookTimeout         *time.Duration
+	WebhookInsecure        *bool
+	WebhookProxy           *string
 	SentryDSN              *string
 	WebHTTPAddress         *string
 	TaintNode              *bool
@@ -96,6 +98,8 @@ var config = Type{
 	WebHookTimeout:         flag.Duration("webhook.timeout", defaultWebHookTimeout, "request timeout"),
 	WebHookTemplate:        flag.String("webhook.template", os.Getenv("WEBHOOK_TEMPLATE"), "request body"),
 	WebHookTemplateFile:    flag.String("webhook.template-file", os.Getenv("WEBHOOK_TEMPLATE_FILE"), "path to request body template file"),
+	WebhookInsecure:        flag.Bool("webhook.insecureSkip", true, "skip tls verification for webhook"),
+	WebhookProxy:           flag.String("webhook.http-proxy", os.Getenv("WEBHOOK_HTTP_PROXY"), "use http proxy for webhook"),
 	SentryDSN:              flag.String("sentry.dsn", "", "sentry DSN"),
 	WebHTTPAddress:         flag.String("web.address", ":17923", ""),
 	TaintNode:              flag.Bool("taint.node", false, "Taint the node before cordon and draining"),

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -34,7 +34,7 @@ const (
 )
 
 var httpClient = &http.Client{
-	Transport: metrics.NewInstrumenter("events", false).InstrumentedRoundTripper(),
+	Transport: metrics.NewInstrumenter("events").InstrumentedRoundTripper(),
 }
 
 type Reader struct {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -77,7 +77,35 @@ func TestKubernetesMetrics(t *testing.T) {
 func TestInstrumenter(t *testing.T) {
 	t.Parallel()
 
-	instrumenter := metrics.NewInstrumenter("test", false)
+	instrumenter := metrics.NewInstrumenter("test")
+
+	r, err := instrumenter.InstrumentedRoundTripper().RoundTrip(httptest.NewRequest(http.MethodGet, ts.URL, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Body.Close()
+}
+
+func TestInstrumenterProxy(t *testing.T) {
+	t.Parallel()
+
+	instrumenter := metrics.NewInstrumenter("testproxy").
+		WithInsecureSkipVerify(true).
+		WithProxy(ts.URL)
+
+	r, err := instrumenter.InstrumentedRoundTripper().RoundTrip(httptest.NewRequest(http.MethodGet, ts.URL, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Body.Close()
+}
+
+func TestInstrumenterBabProxy(t *testing.T) {
+	t.Parallel()
+
+	instrumenter := metrics.NewInstrumenter("testbadproxy").
+		WithInsecureSkipVerify(true).
+		WithProxy("badproxy://badproxy:badproxy")
 
 	r, err := instrumenter.InstrumentedRoundTripper().RoundTrip(httptest.NewRequest(http.MethodGet, ts.URL, nil))
 	if err != nil {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -20,17 +20,18 @@ import (
 	"os"
 
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/config"
-	"github.com/maksim-paskal/aks-node-termination-handler/pkg/metrics"
 	"github.com/maksim-paskal/aks-node-termination-handler/pkg/template"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-var client = &http.Client{
-	Transport: metrics.NewInstrumenter("webhook", true).InstrumentedRoundTripper(),
-}
+var client = &http.Client{}
 
 var errHTTPNotOK = errors.New("http result not OK")
+
+func SetHTTPClient(c *http.Client) {
+	client = c
+}
 
 func SendWebHook(ctx context.Context, obj *template.MessageType) error {
 	ctx, cancel := context.WithTimeout(ctx, *config.Get().WebHookTimeout)


### PR DESCRIPTION
Webhooks using custom http client, enable proxy support in this client.

add new flags:
- --webhook.insecureSkip (to disable TLS verification, default true)
- --webhook.http-proxy (to use http-proxy for webhook requests, default empty, proxy not used for making request)

Closes: #88 