### PR TITLE
feat: add support for NetworkPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,3 +333,16 @@ aks-node-termination-handler/aks-node-termination-handler \
 --set priorityClassName=system-node-critical \
 --set hostNetwork=true
 ```
+
+## NetworkPolicy support
+
+To limit what the workload can communicate with, Networkpolicy can be added via `--set networkPolicy.enabled=true`. To only allow egress communication towards required endpoints, supply the control plane IP address via  `--set networkPolicy.controlPlaneIP=10.11.12.13`. Additional egress rules can be added via `--set networkPolicy.additionalEgressRules=[]`, see the chart-provided `values.yaml` file for examples.
+
+```bash
+helm upgrade aks-node-termination-handler \
+--install \
+--namespace kube-system \
+aks-node-termination-handler/aks-node-termination-handler \
+--set networkPolicy.enabled=true \
+--set networkPolicy.controlPlaneIP=10.11.12.2
+```

--- a/charts/aks-node-termination-handler/Chart.yaml
+++ b/charts/aks-node-termination-handler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 icon: https://helm.sh/img/helm.svg
 name: aks-node-termination-handler
-version: 1.1.6
+version: 1.1.7
 description: Gracefully handle Azure Virtual Machines shutdown within Kubernetes
 maintainers:
 - name: maksim-paskal  # Maksim Paskal

--- a/charts/aks-node-termination-handler/templates/networkpolicy.yaml
+++ b/charts/aks-node-termination-handler/templates/networkpolicy.yaml
@@ -1,0 +1,47 @@
+{{ if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  egress:
+  - ports:
+    - port: 80
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 169.254.169.254/32
+  - ports:
+    - port: 443
+      protocol: TCP
+{{- if .Values.networkPolicy.controlPlaneIP }}
+    to:
+    - ipBlock:
+        cidr: {{ .Values.networkPolicy.controlPlaneIP }}/32
+{{- end }}
+{{- if .Values.networkPolicy.additionalEgressRules }}
+{{ toYaml .Values.networkPolicy.additionalEgressRules | indent 2 }}
+{{- end }}
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+  ingress:
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - port: 17923
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  policyTypes:
+  - Ingress
+  - Egress
+{{ end }}

--- a/charts/aks-node-termination-handler/values.yaml
+++ b/charts/aks-node-termination-handler/values.yaml
@@ -27,6 +27,17 @@ configMap:
 extraVolumes: []
 extraVolumeMounts: []
 
+networkPolicy:
+  enabled: false
+  # controlPlaneIP: "123.X.X.X" # If not provided, network policy will allow all access to port 443/tcp
+  # additionalEgressRules:
+  # - ports:
+  #   - port: 443
+  #     protocol: TCP
+  #   to:
+  #   - ipBlock:
+  #       cidr: 124.X.X.X/24
+
 metrics:
   addAnnotations: true
 


### PR DESCRIPTION
Adding support for NetworkPolicy

For users who needs to lock down workloads with NetworkPolicies, this will add support for this requirement.

Note that this assumes that the control plane API is available on port 443.

 ```bash
helm template . --set networkPolicy.enabled=true --set networkPolicy.controlPlaneIP=10.11.12.2
```
Generates the following diff from the current main branch:
```diff
1a2,43
> # Source: aks-node-termination-handler/templates/networkpolicy.yaml
> apiVersion: networking.k8s.io/v1
> kind: NetworkPolicy
> metadata:
>   name: release-name
> spec:
>   egress:
>   - ports:
>     - port: 80
>       protocol: TCP
>     to:
>     - ipBlock:
>         cidr: 169.254.169.254/32
>   - ports:
>     - port: 443
>       protocol: TCP
>     to:
>     - ipBlock:
>         cidr: 10.11.12.2/32
>   - ports:
>     - port: 53
>       protocol: UDP
>     - port: 53
>       protocol: TCP
>     to:
>     - namespaceSelector: {}
>       podSelector:
>         matchLabels:
>           k8s-app: kube-dns
>   ingress:
>   - from:
>     - namespaceSelector: {}
>     ports:
>     - port: 17923
>       protocol: TCP
>   podSelector:
>     matchLabels:
>       app: release-name
>   policyTypes:
>   - Ingress
>   - Egress
> ---

```