### PR TITLE
fix: disable golangci-lint auto-fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@
 version: "2"
 run:
   timeout: 5m
-issues:
-  fix: true
 linters:
   default: all
   settings:


### PR DESCRIPTION
## Summary

- Removes `issues.fix: true` from `.golangci.yml`

The auto-fix feature rewrites files in place when running `golangci-lint run`. This caused two problems:
1. It silently modified source files during CI lint checks
2. The `noinlineerr` auto-fix introduced `err :=` duplicate declarations in the same scope, breaking compilation