### PR TITLE
fix: resolve golangci-lint v2 errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ run:
 issues:
   fix: true
 linters:
-  default: all
   settings:
     lll:
       line-length: 200

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -48,7 +48,7 @@ func debugHandler(w http.ResponseWriter, r *http.Request) {
 		log.WithError(err).Fatal()
 	}
 
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck
 
 	request = append(request, "--BODY--")
 	request = append(request, string(bodyBytes))

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -115,7 +115,7 @@ func (r *Reader) getScheduledEvents(ctx context.Context) (*types.ScheduledEvents
 		return nil, errors.Wrap(err, "error in client.Do(req)")
 	}
 
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	log.Debugf("response status: %s", resp.Status)
 

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -143,7 +143,7 @@ func TestReadingEvents(t *testing.T) { //nolint:funlen
 		eventReader.Endpoint = testServer.URL + "/document"
 		eventReader.AzureResource = "resource1"
 		eventReader.BeforeReading = func(_ context.Context) error {
-			return errors.New("error in BeforeReading") //nolint:goerr113
+			return errors.New("error in BeforeReading") //nolint:err113
 		}
 		eventReader.EventReceived = func(_ context.Context, event types.ScheduledEventsEvent) (bool, error) {
 			receivedDocument = event

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -57,7 +57,7 @@ func TestMetricsHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	if m := "aks_node_termination_handler_apiserver_request_duration"; !strings.Contains(string(body), m) {
 		t.Fatalf("no metric %s found", m)
@@ -83,7 +83,7 @@ func TestInstrumenter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck
 }
 
 func TestInstrumenterWithEmptyProxy(t *testing.T) {
@@ -95,7 +95,7 @@ func TestInstrumenterWithEmptyProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck
 }
 
 func TestInstrumenterProxy(t *testing.T) {
@@ -109,7 +109,7 @@ func TestInstrumenterProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck
 }
 
 func TestInstrumenterBabProxy(t *testing.T) {
@@ -123,5 +123,5 @@ func TestInstrumenterBabProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -125,13 +125,11 @@ func printType(prefix string, message interface{}) {
 				}
 			}
 
-			buf.WriteString(fmt.Sprintf(
-				"| `{{ .%s%s }}` | %v | %v |\n",
+			fmt.Fprintf(&buf, "| `{{ .%s%s }}` | %v | %v |\n",
 				prefix,
 				typeOfS.Field(i).Name,
 				typeOfS.Field(i).Tag.Get("description"),
-				value,
-			))
+				value)
 		}
 	}
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -85,7 +85,7 @@ func SendWebHook(ctx context.Context, obj *template.MessageType) error {
 	if err != nil {
 		return errors.Wrap(err, "error in client.Do")
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	log.Infof("response status: %s", resp.Status)
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-//nolint:goerr113
+//nolint:err113
 package webhook_test
 
 import (
@@ -74,7 +74,7 @@ func testWebhookRequest(r *http.Request) error {
 		return errors.New("Request URI is not correct")
 	}
 
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck
 
 	body, _ := io.ReadAll(r.Body)
 


### PR DESCRIPTION
## Summary

- Rename `goerr113` nolint directives to `err113` — the linter was renamed in golangci-lint v2
- Add `//nolint:errcheck` to deferred `Body.Close()` calls in `events.go`, `webhook.go`, `mock.go`, and test files — closing an HTTP response body in a defer has no recoverable error path
- Use `fmt.Fprintf` instead of `buf.WriteString(fmt.Sprintf(...))` in `template_test.go` (flagged by golangci-lint autofix)
- Remove `default: all` from `.golangci.yml` (pre-existing staged change)

## Test plan

- [ ] `golangci-lint run` reports `0 issues`
- [ ] Existing tests continue to pass